### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Lint with flake8 & isort
       run: |
         pip install flake8 isort
-        flake8 --count --max-complexity=15 --show-source --statistics
+        flake8 --count --max-complexity=14 --show-source --statistics
         isort --check-only .
 
     - name: Check typing with mypy

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,5 +47,5 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.4.1
       if: github.event_name == 'release'
       with:
-        user: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/doc/releasing.rst
+++ b/doc/releasing.rst
@@ -15,7 +15,7 @@ Address any failures before releasing.
 2. Tag the release candidate version, i.e. with a ``rcN`` suffix, and push::
 
     $ git tag v1.2.3rc1
-    $ git push --tags
+    $ git push --tags origin master
 
 3. Check:
 
@@ -31,7 +31,7 @@ Address any failures before releasing.
 4. (optional) Tag the release itself and push::
 
     $ git tag v1.2.3
-    $ git push --tags
+    $ git push --tags origin master
 
    This step (but *not* step (2)) can also be performed directly on GitHub; see (5), next.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,13 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+Bug fixes
+---------
+
+- :meth:`.Computer.add_single` incorrectly calls :meth:`.check_keys` on iterables (e.g. :class:`pandas.DataFrame`) that are not computations (:pull:`36`).
 
 v1.1.0 (2021-02-16)
 ===================

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -49,7 +49,8 @@ def iamc(c: Computer, info):
     collapse_func = collapse_info.pop("callback", util.collapse)
 
     # Use the Computer method to add the coversion step
-    keys.extend(
+    # NB convert_pyam() returns a single key when applied to a single key
+    keys.append(
         c.convert_pyam(
             keys[-1],
             rename=info.pop("rename", {}),

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -318,9 +318,12 @@ class Computer:
                 # Key already exists in graph
                 raise KeyExistsError(key)
 
-            # Check that keys used in *comp* are in the graph
-            keylike = filter(lambda e: isinstance(e, (str, Key)), computation)
-            self.check_keys(*keylike)
+            # Check valid computations: a tuple with a callable, or a list of other
+            # keys. Don't check a single value that is iterable, e.g. pd.DataFrame
+            if isinstance(computation, (list, tuple)):
+                # Check that keys used in *comp* are in the graph
+                keylike = filter(lambda e: isinstance(e, (str, Key)), computation)
+                self.check_keys(*keylike)
 
         if index:
             # String equivalent of *key* with all dimensions dropped, but name

--- a/genno/core/exceptions.py
+++ b/genno/core/exceptions.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 
 
 class ComputationError(Exception):
-    """Wrapper to print intelligible exception information for :meth:`.get`.
+    """Wrapper to print intelligible exception information for :meth:`.Computer.get`.
 
     In order to aid in debugging, this helper:
 

--- a/genno/tests/test_config.py
+++ b/genno/tests/test_config.py
@@ -7,7 +7,6 @@ from genno import Computer, Key, configure
 from genno.compat.pyam import HAS_PYAM
 from genno.config import HANDLERS, handles
 
-
 # NB ixmp is currently used in the genno test suite: ixmp.testing.run_notebook is
 #    imported by test_exceptions.py. This in turn cases ixmp to register its own
 #    handlers: 2 new, and 1 overriding the built-in one for "units:".


### PR DESCRIPTION
- In `Computer.add_single()`, only call `Computer.check_keys()` on an argument if it is a computation (list or tuple)—not another iterable like a pd.DataFrame.
- When handling `iamc:` config sections, correctly collect the single key returned by `Computer.convert_pyam()`.