### PR TITLE
Adjust to sparse 0.12; enhance AttrSeries.{assign_coords,sel}

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,6 +66,7 @@ intersphinx_mapping = {
     "plotnine": ("https://plotnine.readthedocs.io/en/stable/", None),
     "pyam": ("https://pyam-iamc.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
+    "xarray": ("https://xarray.pydata.org/en/stable/", None),
 }
 
 # -- Options for sphinx.ext.todo -------------------------------------------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,14 @@ Next release
 
 - Bump minimum version of :mod:`sparse` from 0.10 to 0.12 and adjust to changes in this version (:pull:`39`)
 
+  - Remove :meth:`.SparseDataArray.equals`, obviated by improvements in :mod:`sparse`.
+
+- Improve :class:`.AttrSeries` (:pull:`39`)
+
+  - Implement :meth:`~.AttrSeries.drop_vars` and :meth:`~.AttrSeries.expand_dims`.
+  - :meth:`~.AttrSeries.assign_coords` can relabel an entire dimension.
+  - :meth:`~.AttrSeries.sel` can accept :class:`.DataArray` indexers and rename/combine dimensions.
+
 v1.2.1 (2021-03-08)
 ===================
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,10 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bump minimum version of :mod:`sparse` from 0.10 to 0.12 and adjust to changes in this version (:pull:`39`)
 
 v1.2.1 (2021-03-08)
 ===================

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -111,9 +111,7 @@ def aggregate(quantity, groups, keep):
 
         # Aggregate each group
         for group, members in dim_groups.items():
-            agg = (
-                quantity.sel({dim: members}).sum(dim=dim).assign_coords(**{dim: group})
-            )
+            agg = quantity.sel({dim: members}).sum(dim=dim).expand_dims({dim: [group]})
 
             if isinstance(agg, AttrSeries):
                 # .transpose() is necessary for AttrSeries

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -114,6 +114,13 @@ class AttrSeries(pd.Series, Quantity):
         """Like :meth:`xarray.DataArray.drop`."""
         return self.droplevel(label)
 
+    def drop_vars(
+        self, names: Union[Hashable, Iterable[Hashable]], *, errors: str = "raise"
+    ):
+        """Like :meth:`xarray.DataArray.drop_vars`."""
+
+        return self.droplevel(names)
+
     def ffill(self, dim: Hashable, limit: int = None):
         """Like :meth:`xarray.DataArray.ffill`."""
         return self.__class__(

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -142,6 +142,23 @@ class AttrSeries(pd.Series, Quantity):
 
         return self.droplevel(names)
 
+    def expand_dims(
+        self,
+        dim: Union[None, Mapping[Hashable, Any]] = None,
+        axis=None,
+        **dim_kwargs: Any,
+    ):
+        dim = either_dict_or_kwargs(dim, dim_kwargs, "expand_dims")
+        if axis is not None:
+            raise NotImplementedError  # pragma: no cover
+
+        result = self
+        for name, values in reversed(list(dim.items())):
+            print(name, values)
+            result = pd.concat([result] * len(values), keys=values, names=[name])
+
+        return result
+
     def ffill(self, dim: Hashable, limit: int = None):
         """Like :meth:`xarray.DataArray.ffill`."""
         return self.__class__(

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -221,9 +221,11 @@ class AttrSeries(pd.Series, Quantity):
 
             # Check contents of indexers
             if any(ds.isnull().any().values()):
-                raise ValueError(f"indexers have uneven lengths: {ds.notnull().sum()}")
+                raise IndexError(
+                    f"Dimensions of indexers mismatch: {ds.notnull().sum()}"
+                )
             elif len(ds.dims) > 1:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     f"map to > 1 dimensions {repr(ds.dims)} with AttrSeries.sel()"
                 )
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -182,7 +182,9 @@ class AttrSeries(pd.Series, Quantity):
                     # No MultiIndex; use .loc with a slice to avoid returning scalar
                     return self.loc[slice(key, key)]
 
-        if all(isinstance(i, xr.DataArray) for i in indexers.values()):
+        if len(indexers) and all(
+            isinstance(i, xr.DataArray) for i in indexers.values()
+        ):
             # DataArray indexers
 
             # Combine indexers in a data set; dimensions are aligned
@@ -229,6 +231,7 @@ class AttrSeries(pd.Series, Quantity):
             # Other indexers
 
             # Iterate over dimensions
+            idx = []
             for dim in self.dims:
                 # Get an indexer for this dimension
                 i = indexers.get(dim, slice(None))

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Hashable, Iterable, Mapping, Sequence, Union
+from typing import Any, Hashable, Iterable, Mapping, Union
 
 import pandas as pd
 import pandas.core.indexes.base as ibase

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -4,6 +4,7 @@ from typing import Any, Hashable, Mapping
 import pandas as pd
 import pandas.core.indexes.base as ibase
 import xarray as xr
+from xarray.core.utils import either_dict_or_kwargs
 
 from genno.core.quantity import Quantity
 
@@ -148,9 +149,7 @@ class AttrSeries(pd.Series, Quantity):
 
     def sel(self, indexers=None, drop=False, **indexers_kwargs):
         """Like :meth:`xarray.DataArray.sel`."""
-        indexers = xr.core.utils.either_dict_or_kwargs(
-            indexers, indexers_kwargs, "indexers"
-        )
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "indexers")
 
         if len(indexers) == 1:
             level, key = list(indexers.items())[0]
@@ -182,7 +181,7 @@ class AttrSeries(pd.Series, Quantity):
         **shifts_kwargs: int,
     ):
         """Like :meth:`xarray.DataArray.shift`."""
-        shifts = xr.core.utils.either_dict_or_kwargs(shifts, shifts_kwargs, "shift")
+        shifts = either_dict_or_kwargs(shifts, shifts_kwargs, "shift")
         if len(shifts) > 1:
             raise NotImplementedError(
                 f"{self.__class__.__name__}.shift() with > 1 dimension"

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -24,8 +24,9 @@ class AttrSeries(pd.Series, Quantity):
     """:class:`pandas.Series` subclass imitating :class:`xarray.DataArray`.
 
     The AttrSeries class provides similar methods and behaviour to
-    :class:`xarray.DataArray`, so that :mod:`genno.computations` methods can use xarray-
-    like syntax.
+    :class:`xarray.DataArray`, so that :mod:`genno.computations` functions and user
+    code can use xarray-like syntax. In particular, this allows such code to be agnostic
+    about the order of dimensions.
 
     Parameters
     ----------
@@ -121,7 +122,7 @@ class AttrSeries(pd.Series, Quantity):
         return result
 
     def cumprod(self, dim=None, axis=None, skipna=None, **kwargs):
-        """Like :attr:`xarray.DataArray.cumprod`."""
+        """Like :meth:`xarray.DataArray.cumprod`."""
         if axis:
             log.info(f"{self.__class__.__name__}.cumprod(…, axis=…) is ignored")
 
@@ -155,6 +156,7 @@ class AttrSeries(pd.Series, Quantity):
         axis=None,
         **dim_kwargs: Any,
     ):
+        """Like :meth:`xarray.DataArray.expand_dims`."""
         dim = either_dict_or_kwargs(dim, dim_kwargs, "expand_dims")
         if axis is not None:
             raise NotImplementedError  # pragma: no cover

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -20,7 +20,6 @@ class Quantity:
         """Like :meth:`xarray.DataArray.to_series`."""
         # Provided only for type-checking in other packages. AttrSeries implements;
         # SparseDataArray uses the xr.DataArray method.
-        raise RuntimeError
 
     @classmethod
     def from_series(cls, series, sparse=True):

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -54,6 +54,12 @@ class Quantity:
 
             # Unpack a single column; use its name if not overridden by `name`
             return data.iloc[:, 0], (name or data.columns[0])
+        # NB would prefer to do this, but pandas has several bugs for MultiIndex with
+        #    only 1 level
+        # elif (
+        #     isinstance(data, pd.Series) and not isinstance(data.index, pd.MultiIndex)
+        # ):
+        #     return data.set_axis(pd.MultiIndex.from_product([data.index])), name
         else:
             return data, name
 

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -144,11 +144,14 @@ class SparseDataArray(xr.DataArray, Quantity):
         """Override :meth:`~xarray.DataArray.ffill` to auto-densify."""
         return self._sda.dense_super.ffill(dim, limit)._sda.convert()
 
-    def item(self):
-        """Analogous to :meth:`pandas.Series.item`."""
-        if len(self.data.shape) == 0:
+    def item(self, *args):
+        """Like :meth:`~xarray.DataArray.item`."""
+        if len(args):  # pragma: no cover
+            super().item(*args)
+        elif len(self.data.shape) == 0:
             return self.data.data[0]
-        raise ValueError("can only convert an array of size 1 to a Python scalar")
+        else:
+            raise ValueError("can only convert an array of size 1 to a Python scalar")
 
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -144,14 +144,6 @@ class SparseDataArray(xr.DataArray, Quantity):
         """Override :meth:`~xarray.DataArray.ffill` to auto-densify."""
         return self._sda.dense_super.ffill(dim, limit)._sda.convert()
 
-    def equals(self, other) -> bool:
-        """True if two SparseDataArrays have the same dims, coords, and values.
-
-        Overrides :meth:`~xarray.DataArray.equals` for sparse data.
-        """
-        # Necessary for :meth:`xarray.testing.assert_equal` to work.
-        return self.variable.equals(other.variable, equiv=np.equal)
-
     def item(self):
         """Analogous to :meth:`pandas.Series.item`."""
         if len(self.data.shape) == 0:

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -178,6 +178,18 @@ class TestQuantity:
             == tri.loc["x0", "y2"].item()
         )
 
+    def test_sel(self, tri):
+        # Create indexers
+        newdim = [("newdim", ["nd0", "nd1", "nd2"])]
+        x_idx = xr.DataArray(["x2", "x1", "x2"], coords=newdim)
+        y_idx = xr.DataArray(["y4", "y2", "y0"], coords=newdim)
+
+        # Select using the indexers
+        assert_qty_equal(
+            Quantity(xr.DataArray([9.0, 3.0, 5.0], coords=newdim), units="kg"),
+            tri.sel(x=x_idx, y=y_idx),
+        )
+
     def test_shift(self, tri):
         """Test Quantity.shift()."""
         if Quantity._get_class() is SparseDataArray:

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -172,7 +172,12 @@ class TestQuantity:
         r2 = tri.ffill("y")
 
         # Check some filled values
-        assert r2.loc["x0", "y4"] == r2.loc["x0", "y3"] == tri.loc["x0", "y2"]
+        assert (
+            r2.loc["x0", "y4"].item()
+            == r2.loc["x0", "y3"].item()
+            == tri.loc["x0", "y2"].item()
+        )
+
 
     def test_shift(self, tri):
         """Test Quantity.shift()."""

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -188,6 +188,7 @@ class TestQuantity:
         assert_qty_equal(
             Quantity(xr.DataArray([9.0, 3.0, 5.0], coords=newdim), units="kg"),
             tri.sel(x=x_idx, y=y_idx),
+            ignore_extra_coords=True,
         )
 
     def test_shift(self, tri):

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -178,7 +178,6 @@ class TestQuantity:
             == tri.loc["x0", "y2"].item()
         )
 
-
     def test_shift(self, tri):
         """Test Quantity.shift()."""
         if Quantity._get_class() is SparseDataArray:

--- a/genno/tests/test_testing.py
+++ b/genno/tests/test_testing.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from genno.testing import assert_logs
+from genno.testing import assert_logs, assert_qty_allclose, assert_qty_equal
 
 log = logging.getLogger(__name__)
 
@@ -15,3 +15,12 @@ def test_assert_logs(caplog):
         log.debug("bar")
         log.info("baz")
         log.warning("spam and eggs")
+
+
+def test_assert_check_type():
+    """Mismatched types in :func:`assert_qty_equal` and :func:`assert_qty_allclose`."""
+    with pytest.raises(AssertionError):
+        assert_qty_equal(int(1), 2.2)
+
+    with pytest.raises(AssertionError):
+        assert_qty_allclose(int(1), 2.2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     pint
     PyYAML
     setuptools >= 41
-    sparse >= 0.10
+    sparse >= 0.12
     xarray
 setup_requires =
     setuptools >= 41


### PR DESCRIPTION
The release of sparse 0.12 caused some tests to begin to fail, e.g. at https://github.com/khaeru/genno/runs/2158389037?check_suite_focus=true#step:15:266

To address these:
- Remove `SparseDataArray.equals()` override, used for comparison. With sparse 0.12, this is correctly handled by sparse & xarray.
- Call `Quantity.item()` to get scalar values from 1-D quantities in one test (TestQuantity.test_ffill()). This comparison of 0-D objects worked with sparse 0.11.2, but no longer works with sparse 0.12.
- Bump minimum version of sparse to 0.12.

Other enhancements:
- AttrSeries.assign_coords() can relabel an entire dimension.
- AttrSeries.sel() can do xarray's reindexing and renaming/merging of dimensions using xr.DataArrays as indexers.