### PR TITLE
Adjust test_assign_coords() for xarray 0.18.2

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -9,6 +9,7 @@ What's new
 Next release
 ============
 
+- Adjust :meth:`.test_assign_coords` for xarray 0.18.2 (:pull:`43`).
 - Make :attr:`Key.dims` order-insensitive so that ``Key("foo", "ab") == Key("foo", "ba")`` (:pull:`42`).
 - Fix “:class:`AttributeError`: 'COO' object has no attribute 'item'” on :meth:`SparseDataArray.item` (:pull:`41`).
 

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -112,12 +112,12 @@ class TestQuantity:
         # Exception raised when the values are of the wrong length
         with pytest.raises(
             ValueError,
-            match="conflicting sizes for dimension 'p': .* and length 3 on 'p'",
+            match="conflicting sizes for dimension 'p': length 2 .* and length 3",
         ):
             a.assign_coords({"p": ["apple", "orange", "banana"]})
         with pytest.raises(
             ValueError,
-            match="conflicting sizes for dimension 'p': .* and length 1 on 'p'",
+            match="conflicting sizes for dimension 'p': length 2 .* and length 1",
         ):
             a.assign_coords({"p": ["apple"]})
 


### PR DESCRIPTION
Addresses CI failures since [2021-05-20](https://github.com/khaeru/genno/actions/runs/859231302).