### PR TITLE
Adjust to order-insensitive Key.dims

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,7 @@ jobs:
         isort --check-only .
 
     - name: Check typing with mypy
+      # Also install packages that provide type hints
       run: |
-        # Also install packages that provide type hints
-        pip install mypy ixmp pytest xarray
+        pip install mypy ixmp pytest types-PyYAML xarray
         mypy .

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,7 +10,7 @@ Next release
 ============
 
 - Adjust :meth:`.test_assign_coords` for xarray 0.18.2 (:pull:`43`).
-- Make :attr:`Key.dims` order-insensitive so that ``Key("foo", "ab") == Key("foo", "ba")`` (:pull:`42`).
+- Make :attr:`Key.dims` order-insensitive so that ``Key("foo", "ab") == Key("foo", "ba")`` (:pull:`42`); make corresponding changes to :class:`Computer` (:pull:`44`).
 - Fix “:class:`AttributeError`: 'COO' object has no attribute 'item'” on :meth:`SparseDataArray.item` (:pull:`41`).
 
 v1.4.0 (2021-04-26)

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -326,11 +326,11 @@ class Computer:
                 self.check_keys(*keylike)
 
         if index:
-            # String equivalent of *key* with all dimensions dropped, but name
-            # and tag retained
+            # String equivalent of `key` with all dimensions dropped, but name and tag
+            # retained, e.g. "foo::bar" for "foo:a-b:bar"; but "foo" for "foo:a-b"
             idx = str(Key.from_str_or_key(key, drop=True)).rstrip(":")
 
-            # Add *key* to the index
+            # Add `key` to the index
             self._index[idx] = key
 
         # Add to the graph
@@ -372,9 +372,9 @@ class Computer:
             self.graph.update(applied)
 
     def get(self, key=None):
-        """Execute and return the result of the computation *key*.
+        """Execute and return the result of the computation `key`.
 
-        Only *key* and its dependencies are computed.
+        Only `key` and its dependencies are computed.
 
         Parameters
         ----------
@@ -432,9 +432,9 @@ class Computer:
     def check_keys(self, *keys):
         """Check that *keys* are in the Computer.
 
-        If any of *keys* is not in the Computer, KeyError is raised.
-        Otherwise, a list is returned with either the key from *keys*, or the
-        corresponding :meth:`full_key`.
+        If any of `keys` is not in the Computer, KeyError is raised. Otherwise, a list
+        is returned with either the key from `keys`, or the corresponding
+        :meth:`full_key`.
         """
         result = []
         missing = []
@@ -627,8 +627,8 @@ class Computer:
         Returns
         -------
         .Key
-            Either `key` (if given) or e.g. ``file:foo.ext`` based on the
-            `path` name, without directory components.
+            Either `key` (if given) or e.g. ``file:foo.ext`` based on the `path` name,
+            without directory components.
 
         See also
         --------
@@ -644,11 +644,16 @@ class Computer:
     add_load_file = add_file
 
     def describe(self, key=None, quiet=True):
-        """Return a string describing the computations that produce *key*.
+        """Return a string describing the computations that produce `key`.
 
-        If *key* is not provided, all keys in the Computer are described.
+        If `key` is not provided, all keys in the Computer are described.
 
-        The string can be printed to the console, if not *quiet*.
+        Unless `quiet`, the string is also printed to the console.
+
+        Returns
+        -------
+        str
+            Description of computations.
         """
         if key is None:
             # Sort with 'all' at the end

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -391,6 +391,8 @@ class Computer:
                 key = self.default_key
             else:
                 raise ValueError("no default reporting key set")
+        else:
+            key = self.check_keys(key)[0]
 
         # Protect 'config' dict, so that dask schedulers do not try to interpret its
         # contents as further tasks. Workaround for

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -487,7 +487,7 @@ class Computer:
         return result[0] if single else tuple(result)
 
     def __contains__(self, name):
-        return name in self.graph
+        return name in self.graph or Key.from_str_or_key(name) in self.graph
 
     # Convenience methods
     def add_product(self, key, *quantities, sums=True):

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -654,7 +654,7 @@ class Computer:
                 sorted(filter(lambda k: k != "all", self.graph.keys())) + ["all"]
             )
         else:
-            key = (key,)
+            key = tuple(self.check_keys(key))
 
         result = describe_recursive(self.graph, key)
         if not quiet:

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -313,6 +313,8 @@ class Computer:
             # Unpack a length-1 tuple
             computation = computation[0]
 
+        key = maybe_convert_str(key)
+
         if strict:
             if key in self.graph:
                 # Key already exists in graph
@@ -753,3 +755,12 @@ class Computer:
 
     # Use convert_pyam as a helper for computations.as_pyam
     add_as_pyam = convert_pyam
+
+
+def maybe_convert_str(key):
+    """Maybe convert `key` into a Key object.
+
+    Allow a string like "foo" with no dimensions or tag to remain as-is.
+    """
+    _key = Key.from_str_or_key(key)
+    return _key if (_key.dims or _key.tag) else key

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -213,7 +213,7 @@ def test_require_compat():
         c.require_compat("_test")
 
 
-def test_add():
+def test_add0():
     """Adding computations that refer to missing keys raises KeyError."""
     c = Computer()
     c.add("a", 3)
@@ -270,6 +270,12 @@ def test_add():
     msg = "unexpected keyword argument 'bad_kwarg'"
     with pytest.raises(TypeError, match=msg):
         c.add("select", "bar", "a", bad_kwarg="foo", index=True)
+
+
+def test_add1():
+    """:meth:`._rewrite_comp` is a no-op for types other that list and tuple."""
+    Computer().add("a", 1, strict=True)
+    Computer().add("a", pd.DataFrame(), strict=True)
 
 
 def test_add_queue(caplog):


### PR DESCRIPTION
This PR follows on #42:
- Add tests for behaviour related to Key dimensions expected by downstream packages, especially iiasa/message_ix.
- Improve handling of keys with dimensions in various orders, in:
  - `Computer.__contains__`
  - `Computer.check_keys`
  - `Computer.describe`
  - `Computer.get`
