### PR TITLE
Improve handling of Key dimension order

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -260,13 +260,16 @@ Top-level classes and functions
    **Notes:**
 
    A Key has the same hash, and compares equal to its :class:`str` representation.
+   A Key also compares equal to another key or :class:`str` with the same dimensions in any other order.
    ``repr(key)`` prints the Key in angle brackets ('<>') to signify that it is a Key object.
 
    >>> str(k1)
    'foo:a-b-c'
    >>> repr(k1)
    '<foo:a-b-c>'
-   >>> hash(k1) == hash('foo:a-b-c')
+   >>> hash(k1) == hash("foo:a-b-c")
+   True
+   >>> k1 == "foo:c-b-a"
    True
 
    Keys are **immutable**: the properties :attr:`name`, :attr:`dims`, and :attr:`tag` are *read-only*, and the methods :meth:`append`, :meth:`drop`, and :meth:`add_tag` return *new* Key objects.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -9,6 +9,11 @@ What's new
 .. Next release
 .. ============
 
+v1.5.2 (2021-07-06)
+===================
+
+- Bugfix: order-insensitive :attr:`Key.dims` broke :meth:`~.Computer.get` in some circumstances (:pull:`46`).
+
 v1.5.1 (2021-07-01)
 ===================
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -484,6 +484,11 @@ class Computer:
                 result.append(all_keys[all_keys.index(value)])
                 return True
 
+            # Match an existing key with dimensions in a different order
+            for k in filter(lambda k_: k_ == value, self.graph.keys()):
+                result.append(k)
+                return True
+
             return False
 
         # Process all keys to produce more useful error messages

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -455,12 +455,17 @@ class Computer:
         name = str(Key.from_str_or_key(name_or_key, drop=True)).rstrip(":")
         return self._index[name]
 
-    def check_keys(self, *keys: Union[str, Key]) -> List[Union[str, Key]]:
+    def check_keys(
+        self, *keys: Union[str, Key], action="raise"
+    ) -> Optional[List[Union[str, Key]]]:
         """Check that `keys` are in the Computer.
 
-        If any of `keys` is not in the Computer, KeyError is raised. Otherwise, a list
-        is returned with either the key from `keys`, or the corresponding
-        :meth:`full_key`.
+        If any of `keys` is not in the Computer and `action` is "raise" (the default)
+        :class:`KeyError` is raised. Otherwise, a list is returned with either the key
+        from `keys`, or the corresponding :meth:`full_key`.
+
+        If `action` is "return" (or any other value), :class:`None` is returned on
+        missing keys.
         """
         result = []
         missing = []
@@ -495,10 +500,13 @@ class Computer:
                 missing.append(key)
 
         if len(missing):
-            # 1 or more keys missing
-            # Suppress traceback from within this function
-            __tracebackhide__ = True
-            raise MissingKeyError(*missing)
+            if action == "raise":
+                # 1 or more keys missing
+                # Suppress traceback from within this function
+                __tracebackhide__ = True
+                raise MissingKeyError(*missing)
+            else:
+                return None
 
         return result
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -316,7 +316,9 @@ class Computer:
         key = maybe_convert_str(key)
 
         if strict:
-            if key in self.graph:
+            try:
+                assert self.check_keys(key, action="return") is None
+            except AssertionError:
                 # Key already exists in graph
                 raise KeyExistsError(key)
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -546,7 +546,11 @@ class Computer:
         return result[0] if single else tuple(result)
 
     def __contains__(self, name):
-        return name in self.graph or Key.from_str_or_key(name) in self.graph
+        # First check using hash (fast), then using comparison (slower) for same key
+        # with dimensions in different order
+        return name in self.graph or any(
+            Key.from_str_or_key(name) == k for k in self.graph.keys()
+        )
 
     # Convenience methods
     def add_product(self, key, *quantities, sums=True):

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -111,7 +111,7 @@ class Key:
 
         @lru_cache(1)
         def _():
-            return hash(str(self.sorted))
+            return hash(str(self))
 
         return _()
 

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -461,6 +461,12 @@ def test_check_keys():
 
     assert [Key("a", "xy"), Key("b", "zy")] == c.check_keys("a:x-y", "b:z-y")
 
+    # All orders
+    c.check_keys("a:y-x", "a:x-y", "b:z-y", "b:y-z")
+
+    # Non-existent keys, both bare strings and those parsed to Key()
+    assert c.check_keys("foo", "foo:bar-baz", action="return") is None
+
 
 def test_dantzig(ureg):
     c = Computer()

--- a/genno/tests/core/test_key.py
+++ b/genno/tests/core/test_key.py
@@ -69,12 +69,13 @@ def test_sorted():
     # Ordered returns a key with sorted dimensions
     assert k1.dims == k2.sorted.dims
 
-    # Keys compare equal to an equivalent string
-    assert k1 == "foo:b-a-c"
-    assert k2 == "foo:b-c-a"
+    # Keys compare equal to an equivalent string and to one another
+    assert k1 == "foo:b-a-c" == k2 == "foo:b-c-a"
 
-    # Keys hash equal
-    assert hash(k1) == hash(k2)
+    # Keys do not hash equal
+    assert hash(k1) == hash("foo:a-b-c")
+    assert hash(k2) == hash("foo:c-b-a")
+    assert hash(k1) != hash(k2)
 
 
 def test_gt_lt():


### PR DESCRIPTION
In 1.5.1, `Computer.get(…)` could fail under the following conditions:
- A computation refers to a Key (or str) like `<foo:x-y>`.
- That key is in the graph, but its dimension are in a different order, e.g. `foo:y-x`.

Then `dask.cull()` (inside `Computer.get()`) would fail to pick up `foo:y-x`, and the computation would get a string instead of the proper input value.

This PR fixes by reverting the behaviour of `Key.__hash__()` to the pre-1.5.0 behaviour: the hash is the hash of the _unsorted_ string representation. At the same time, checks and comparisons are added where keys with different dimension order should be tolerated.