### PR TITLE
Improve performance of Computer.check_keys() and related

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -223,17 +223,15 @@ Top-level classes and functions
    2. zero or more ordered :attr:`dims`, and
    3. an optional :attr:`tag`.
 
-   For example, quantity with three dimensions:
+   For example, for a :math:`\text{foo}` with with three dimensions :math:`a, b, c`:
 
-   # FIXME
-
-   >>> scenario.init_par('foo', ['a', 'b', 'c'], ['apple', 'bird', 'car'])
+   .. math:: \text{foo}^{abc}
 
    Key allows a specific, explicit reference to various forms of “foo”:
 
    - in its full resolution, i.e. indexed by a, b, and c:
 
-     >>> k1 = Key('foo', ['a', 'b', 'c'])
+     >>> k1 = Key("foo", ["a", "b", "c"])
      >>> k1
      <foo:a-b-c>
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -184,7 +184,7 @@ Top-level classes and functions
 
    .. automethod:: convert_pyam
 
-      The :pyam:doc:`IAMC data format <data>` includes columns named 'Model', 'Scenario', 'Region', 'Variable', 'Unit'; one of 'Year' or 'Time'; and 'value'.
+      The :doc:`IAMC data format <pyam:data>` includes columns named 'Model', 'Scenario', 'Region', 'Variable', 'Unit'; one of 'Year' or 'Time'; and 'value'.
 
       Using :meth:`convert_pyam`:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,11 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add :meth:`Key.permute_dims` (:pull:`47`).
+- Improve performance of :meth:`Computer.check_keys` (:pull:`47`).
 
 v1.5.2 (2021-07-06)
 ===================

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -554,7 +554,7 @@ class Computer:
         # First check using hash (fast), then using comparison (slower) for same key
         # with dimensions in different order
         return name in self.graph or any(
-            Key.from_str_or_key(name) == k for k in self.graph.keys()
+            map(self.graph.__contains__, Key.from_str_or_key(name).permute_dims())
         )
 
     # Convenience methods

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -491,14 +491,7 @@ class Computer:
 
             # Possibly convert a string to a Key
             value = maybe_convert_str(value)
-            if isinstance(value, str):
-                return None
-
-            # Same method
-            if value in self._index:
-                return self._index[value]
-
-            if not _permute:
+            if isinstance(value, str) or not _permute:
                 return None
 
             # Try permutations of dimensions

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -179,7 +179,7 @@ class Key:
         """Return a new Key with `tag` appended."""
         return Key(self.name, self.dims, "+".join(filter(None, [self.tag, tag])))
 
-    def iter_sums(self):
+    def iter_sums(self) -> Generator[Tuple["Key", Callable, "Key"], None, None]:
         """Generate (key, task) for all possible partial sums of the Key."""
         from genno import computations
 

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -4,7 +4,7 @@ from itertools import chain, compress
 from typing import Hashable, Iterable, Optional, Tuple, Union
 
 #: Regular expression for valid key strings.
-EXPR = re.compile(r"(?P<name>[^:]+)(:(?P<dims>[^:]*)(:(?P<tag>[^:]*))?)?")
+EXPR = re.compile(r"^(?P<name>[^:]+)(:(?P<dims>([^:-]*-)*[^:-]+)?(:(?P<tag>[^:]*))?)?$")
 
 
 class Key:
@@ -53,8 +53,6 @@ class Key:
                 dims=[] if not groups["dims"] else groups["dims"].split("-"),
                 tag=groups["tag"],
             )
-            if any(len(dim) == 0 for dim in base.dims):
-                raise ValueError(f"Invalid key expression: {repr(value)}")
         elif isinstance(value, cls):
             base = value
         else:

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -58,6 +58,10 @@ class Key:
         else:
             raise TypeError(type(value))
 
+        # Return quickly if no further manipulations are required
+        if not any([drop, append, tag]):
+            return base
+
         # mypy is fussy here
         drop_args: Tuple[Union[str, bool], ...] = tuple(
             [drop] if isinstance(drop, bool) else drop

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -159,23 +159,23 @@ class Key:
     @property
     def sorted(self) -> "Key":
         """A version of the Key with its :attr:`dims` sorted alphabetically."""
-        return Key(self.name, sorted(self.dims), self.tag)
+        return Key(self._name, sorted(self._dims), self._tag)
 
     def drop(self, *dims: Union[str, bool]):
         """Return a new Key with `dims` dropped."""
-        if dims == (True,):
-            new_dims: Iterable[str] = []
-        else:
-            new_dims = filter(lambda d: d not in dims, self.dims)
-        return Key(self.name, new_dims, self.tag)
+        return Key(
+            self._name,
+            [] if dims == (True,) else filter(lambda d: d not in dims, self._dims),
+            self._tag,
+        )
 
     def append(self, *dims: str):
         """Return a new Key with additional dimensions `dims`."""
-        return Key(self.name, list(self.dims) + list(dims), self.tag)
+        return Key(self._name, list(self._dims) + list(dims), self._tag)
 
     def add_tag(self, tag):
         """Return a new Key with `tag` appended."""
-        return Key(self.name, self.dims, "+".join(filter(None, [self.tag, tag])))
+        return Key(self._name, self._dims, "+".join(filter(None, [self._tag, tag])))
 
     def iter_sums(self) -> Generator[Tuple["Key", Callable, "Key"], None, None]:
         """Generate (key, task) for all possible partial sums of the Key."""
@@ -197,7 +197,9 @@ class Key:
         >>> list(k.permute_dims())
         [<A:x-y-z>, <A:x-z-y>, <A:y-x-z>, <A:y-z-x>, <A:z-x-y>, <A:z-y-x>]
         """
-        yield from map(partial(Key, self.name, tag=self.tag), permutations(self.dims))
+        yield from map(
+            partial(Key, self._name, tag=self._tag), permutations(self._dims)
+        )
 
 
 #: Type shorthand for :class:`Key` or any other value that can be used as a key.

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -16,7 +16,7 @@ class Key:
         self._tag = tag or None
 
         self._str = "{}:{}{}".format(
-            name, "-".join(dims), f":{self._tag}" if self._tag else ""
+            name, "-".join(self._dims), f":{self._tag}" if self._tag else ""
         )
         self._hash = hash(self._str)
 

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -188,6 +188,17 @@ class Key:
                 self,
             )
 
+    def permute_dims(self) -> Generator["Key", None, None]:
+        """Generate variants of the Key with dimensions in all possible orders.
+
+        Examples
+        --------
+        >>> k = Key("A", "xyz")
+        >>> list(k.permute_dims())
+        [<A:x-y-z>, <A:x-z-y>, <A:y-x-z>, <A:y-z-x>, <A:z-x-y>, <A:z-y-x>]
+        """
+        yield from map(partial(Key, self.name, tag=self.tag), permutations(self.dims))
+
 
 #: Type shorthand for :class:`Key` or any other value that can be used as a key.
 KeyLike = Union[Key, Hashable]

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -141,7 +141,7 @@ def test_order():
 
     # add() and describe() with dimensions in a different order. The output matches the
     # order given to add().
-    c.add("a:x-y", 1.1)
+    c.add("a:x-y", 1.1, index=True)
     assert "'a:x-y':\n- 1.1" == c.describe("a:y-x")
 
     # Opposite order

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -467,6 +467,10 @@ def test_check_keys():
     # Non-existent keys, both bare strings and those parsed to Key()
     assert c.check_keys("foo", "foo:bar-baz", action="return") is None
 
+    # Check a lookup using the index
+    c.add("a:y-x:foo", index=True)
+    assert [Key("a", "yx", "foo")] == c.check_keys("a::foo")
+
 
 def test_dantzig(ureg):
     c = Computer()

--- a/genno/tests/core/test_key.py
+++ b/genno/tests/core/test_key.py
@@ -59,6 +59,11 @@ def test_from_str(value, expected):
     assert expected == Key.from_str_or_key(value)
 
 
+def test_drop():
+    key = Key.from_str_or_key("out:nl-t-yv-ya-m-nd-c-l-h-hd")
+    assert "out:t-yv-ya-c-l" == key.drop("h", "hd", "m", "nd", "nl")
+
+
 def test_sorted():
     k1 = Key("foo", "abc")
     k2 = Key("foo", "cba")


### PR DESCRIPTION
This PR adjusts the code checking keys with possibly different dimension orders, to improve performance of these operations.

In iiasa/message_ix#492, this is the cause of time-outs executing tutorial notebooks, which are a regression since they did not occur with earlier versions of genno.