### PR TITLE
Fix Paths not serialized properly in .caching

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,13 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+Bug fixes
+---------
+
+- :class:`.Path` not serialized correctly in :mod:`.caching` (:pull:`51`).
 
 v1.8.0 (2021-07-27)
 ===================

--- a/genno/caching.py
+++ b/genno/caching.py
@@ -23,7 +23,7 @@ def _encode(o):
 
 @_encode.register(Path)  # py3.6 compat: must give the type as an argument
 def _encode_path(o: Path):
-    return str(Path)
+    return str(o)
 
 
 class Encoder(json.JSONEncoder):

--- a/genno/tests/test_caching.py
+++ b/genno/tests/test_caching.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 import pytest
 
@@ -12,19 +11,13 @@ class Bar:
 
 
 class TestEncoder:
-    @pytest.mark.parametrize(
-        "value, passes",
-        [
-            (Path.cwd(), True),
-            (lambda foo: foo, False),
-        ],
-    )
-    def test_default(self, value, passes):
-        if passes:
-            Encoder().default(value)
-        else:
-            with pytest.raises(TypeError):
-                Encoder().default(value)
+    def test_default(self, tmp_path):
+        # Different paths encode differently
+        assert Encoder().default(tmp_path / "x ") != Encoder().default(tmp_path / "y")
+
+        # Lambda function is not encodable
+        with pytest.raises(TypeError):
+            Encoder().default(lambda foo: foo)
 
     @pytest.mark.parametrize("types", [Bar, object])
     def test_ignore(self, monkeypatch, types):


### PR DESCRIPTION
#50/v1.8.0 introduced an error in .caching:
https://github.com/khaeru/genno/blob/fb1f72e3ede579667c64d87eb67ddd7f7c954baf/genno/caching.py#L24-L26

This always returns the same value, "<class 'pathlib.Path'>", instead of a different value for different paths.

This PR fixes the bug.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, bugfix
- [x] Update doc/whatsnew.rst
