### PR TITLE
Correct use of either_dict_or_kwargs() in AttrSeries.sel()

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,8 +18,8 @@ jobs:
     - uses: actions/setup-python@v2
       # Uncomment and set this to match the "Latest version testable on GitHub
       # Actions" in pytest.yaml, if that is not the default used by setup-python
-      # with:
-      #  python-version: "3.9"
+      with:
+       python-version: "3.9"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,15 +21,16 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - "3.7"  # Earliest version supported by genno; matches xarray
+        - "3.7"  # Earliest version supported by genno; matches xarray/setup.cfg
         - "3.8"
-        - "3.9"
-        - "3.10"  # Latest Python release / latest testable on GitHub Actions
+        - "3.9"  # Latest testable on GitHub Actions
 
-        # For development versions of Python, compiled binary wheels are not
-        # available for some dependencies, e.g. llvmlite, numba, numpy, and/or
-        # pandas. Compiling these on the job runner requires a more elaborate
-        # build environment, currently out of scope for genno.
+        # For new releases or development versions of Python, compiled binary
+        # wheels may not be available for some dependencies, e.g. llvmlite,
+        # numba, numpy, and/or pandas. Compiling these on the job runner
+        # requires a more elaborate build environment, currently out of scope
+        # for genno. Exclude these versions from CI.
+        # - "3.10"  # Latest Python release / latest supported by genno
         # - "3.11.0-alpha.2"  # Development version
 
       fail-fast: false

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,21 +21,16 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - "3.6"  # Earliest version supported by genno; matches xarray
+        - "3.7"  # Earliest version supported by genno; matches xarray
         - "3.8"
-        - "3.9"  # Latest Python release / latest testable on GitHub Actions
+        - "3.9"
+        - "3.10"  # Latest Python release / latest testable on GitHub Actions
 
         # For development versions of Python, compiled binary wheels are not
         # available for some dependencies, e.g. llvmlite, numba, numpy, and/or
         # pandas. Compiling these on the job runner requires a more elaborate
         # build environment, currently out of scope for genno.
-        # - "3.10.0-alpha.1"  # Development version
-
-        exclude:
-        # This job triggers errors when importing ixmp.testing: no module named
-        # ixmp.backend. Not critical, since it's upstream.
-        - os: windows-latest
-          python-version: "3.6"
+        # - "3.11.0-alpha.2"  # Development version
 
       fail-fast: false
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,11 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Fix error messages raised by :meth:`.AttrSerie.sel` on incorrect usage (:pull:`52`).
+- :mod:`genno` no longer supports Python 3.6 or earlier, following :mod:`xarray` (:pull:`52`)
 
 v1.8.1 (2021-07-27)
 ===================

--- a/genno/caching.py
+++ b/genno/caching.py
@@ -21,7 +21,7 @@ def _encode(o):
     return json.JSONEncoder().default(o)
 
 
-@_encode.register(Path)  # py3.6 compat: must give the type as an argument
+@_encode.register
 def _encode_path(o: Path):
     return str(o)
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -298,7 +298,7 @@ class AttrSeries(pd.Series, Quantity):
 
     def sel(self, indexers=None, drop=False, **indexers_kwargs):
         """Like :meth:`xarray.DataArray.sel`."""
-        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "indexers")
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 
         if len(indexers) == 1:
             level, key = list(indexers.items())[0]

--- a/genno/testing.py
+++ b/genno/testing.py
@@ -189,10 +189,8 @@ def assert_logs(caplog, message_or_messages=None, at_level=None):
         # the level of the logger for the whole package (parent of the current module)
         ctx = caplog.at_level(at_level, logger=__name__.split(".")[0])
     else:
-        # Python 3.6 compatibility: use suppress for nullcontext
-        nullcontext = getattr(contextlib, "nullcontext", contextlib.suppress)
         # ctx does nothing
-        ctx = nullcontext()
+        ctx = contextlib.nullcontext()
 
     try:
         with ctx:

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -678,7 +678,8 @@ def test_units(ureg):
     """Test handling of units within computations."""
     c = Computer()
 
-    assert isinstance(c.unit_registry, pint.UnitRegistry)
+    # One of the two classes may be referenced
+    assert isinstance(c.unit_registry, (pint.UnitRegistry, pint.ApplicationRegistry))
 
     # Create some dummy data
     dims = dict(coords=["a b c".split()], dims=["x"])

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -310,11 +310,7 @@ def test_add_queue(caplog):
     # Failures without raising an exception
     c.add(queue, max_tries=3, fail=logging.INFO)
     assert "Failed 3 times to add:" in caplog.messages
-
-    # NB the following works in Python >= 3.7, but not 3.6, where it ends ",)"
-    # assert "    with MissingKeyError('foo-3')" in caplog.messages
-    expr = re.compile(r"    with MissingKeyError\('foo-3',?\)")
-    assert any(expr.match(m) for m in caplog.messages)
+    assert "    with MissingKeyError('foo-3')" in caplog.messages
 
     queue = [((Key("bar", list("abcd")), 10), dict(sums=True))]
     added = c.add_queue(queue)

--- a/genno/tests/core/test_exceptions.py
+++ b/genno/tests/core/test_exceptions.py
@@ -9,18 +9,14 @@ from genno.testing import assert_logs
 def test_computationerror(caplog):
     ce_none = ComputationError(None)
 
-    # Message ends with ',)' on Python 3.6, only ')' on Python 3.7
     msg = (
         "Exception raised while formatting None:\nAttributeError"
-        "(\"'NoneType' object has no attribute '__traceback__'\""
+        "(\"'NoneType' object has no attribute '__traceback__'\")"
     )
     with assert_logs(caplog, msg):
         str(ce_none)
 
 
-# The TypeError message differs:
-# - Python 3.6: "must be str, not float"
-# - Python 3.7: "can only concatenate str (not "float") to str"
 EXPECTED = re.compile(
     r"""computing 'test' using:
 
@@ -31,8 +27,7 @@ Use Computer.describe\(...\) to trace the computation.
 Computation traceback:
   File "(<ipython-input-\d*-\w+>|[^"]*\.py)", line 4, in fail
     'x' \+ 3.4  # Raises TypeError
-TypeError: .*str.*float.*
-"""
+TypeError: can only concatenate str \(not "float"\) to str.*"""
 )
 
 

--- a/genno/tests/test_caching.py
+++ b/genno/tests/test_caching.py
@@ -39,7 +39,7 @@ class TestEncoder:
             Encoder().default(Bar())
 
         # Register a serializer
-        @Encoder.register(Bar)  # py3.6 compat: must give the type as an argument
+        @Encoder.register
         def _serialize_bar(o: Bar):
             return dict(bar=42)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,16 +17,16 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
 
 [options]
 packages = genno
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 install_requires =
     dask [array] >= 2.14
@@ -35,7 +35,7 @@ install_requires =
     PyYAML
     setuptools >= 41
     sparse >= 0.12
-    xarray
+    xarray >= 0.17
 setup_requires =
     setuptools >= 41
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,9 +86,6 @@ profile = black
 max-line-length = 88
 
 [mypy]
-# Empty section required as of mypy 0.800;
-# see https://github.com/python/mypy/issues/9940
-
 [mypy-dask.*]
 ignore_missing_imports = True
 [mypy-numpy.*]


### PR DESCRIPTION
The third argument gives the name of the method, not the argument. This improves the error message shown when the function is miscalled.

Also:
- Bump Python requirement to 3.7, matching xarray >=0.17.
- Advertise support for Python 3.10, although this is pending upstream dependencies like numba and llvmlite. See iiasa/message_ix#532 for closer tracking of these.
- Adjust for pint 0.18.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- [x] Update doc/whatsnew.rst
