### PR TITLE
Improve typing of Quantity, Computer

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -72,7 +72,10 @@ jobs:
       run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Install Python package and dependencies
-      run: pip install --editable .[docs,tests]
+      # pyam-iamc (IAMconsortium/pyam#589) forces pint 0.17; override
+      run: |
+        pip install --editable .[docs,tests]
+        pip install --upgrade pint
 
     - name: Run test suite using pytest
       run: pytest genno --trace-config --verbose --cov-report=xml --cov-report=term --color=yes

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,14 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+Note that installing ``genno[pyam]`` (including via ``genno[compat]``) currently forces the installation of an old version of :mod:`pint`; version 0.17 or earlier.
+Users wishing to use :mod:`genno.compat.pyam` should first install ``genno[pyam]``, then ``pip install --upgrade pint`` to restore a recent version of pint (0.18 or newer) that is usable with genno.
+
+- :func:`computations.concat` works with :class:`.AttrSeries` with misaligned dimensions (:pull:`53`).
+- Improve typing of :class:`.Quantity` and :class:`.Computer` to help with using `mypy <https://mypy.readthedocs.io>`_ on code that uses :mod:`genno` (:pull:`53`).
 
 v1.9.0 (2021-11-23)
 ===================

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -269,7 +269,11 @@ def concat(*objs, **kwargs):
                 # Something else; warn and discard
                 log.warning(f"Ignore concat(…, dim={repr(dim)})")
 
-        return pd.concat(objs, **kwargs)
+        # Ensure objects have aligned dimensions
+        _objs = [next(objs)]
+        _objs.extend(map(lambda o: o.align_levels(_objs[0]), objs))
+
+        return pd.concat(_objs, **kwargs)
     else:
         # Correct fill-values
         return xr.concat(objs, **kwargs)._sda.convert()

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -5,7 +5,6 @@ from typing import Any, Hashable, Iterable, Mapping, Union
 import numpy as np
 import pandas as pd
 import pandas.core.indexes.base as ibase
-import pint
 import xarray as xr
 from xarray.core.utils import either_dict_or_kwargs
 
@@ -83,13 +82,6 @@ class AttrSeries(pd.Series, Quantity):
     def from_series(cls, series, sparse=None):
         """Like :meth:`xarray.DataArray.from_series`."""
         return AttrSeries(series)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set the units of the Quantity."""
-        if name == "units":
-            self.attrs["_unit"] = pint.get_application_registry().Unit(value)
-        else:
-            super().__setattr__(name, value)
 
     def assign_coords(self, coords=None, **coord_kwargs):
         """Like :meth:`xarray.DataArray.assign_coords`."""

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -13,8 +13,8 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    MutableSequence,
     Optional,
-    Sequence,
     Tuple,
     Union,
     cast,
@@ -60,7 +60,7 @@ class Computer:
     #: :mod:`genno.computations`. :meth:`require_compat` appends additional modules,
     #: e.g. #: :mod:`.compat.pyam.computations`, to this list. User code may also add
     #: modules to this list.
-    modules: Sequence[ModuleType] = [computations]
+    modules: MutableSequence[ModuleType] = [computations]
 
     def __init__(self, **kwargs):
         self.graph = {"config": {}}

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -1,8 +1,10 @@
 from functools import update_wrapper
-from typing import Any, Hashable, Mapping, Tuple
+from typing import Any, Hashable, Mapping, Tuple, Union
 
+import numpy as np
 import pandas as pd
 import pint
+import xarray
 
 #: Name of the class used to implement :class:`.Quantity`.
 CLASS = "AttrSeries"
@@ -56,7 +58,21 @@ class Quantity:
             "_unit", pint.get_application_registry().dimensionless
         )
 
-    # For mypy
+    # Type hints for mypy in downstream applications
+    def __len__(self) -> int:
+        ...
+
+    def __truediv__(self, other) -> "Quantity":
+        ...
+
+    @property
+    def attrs(self) -> dict[Any, Any]:
+        ...
+
+    @property
+    def coords(self) -> xarray.core.coordinates.DataArrayCoordinates:
+        ...
+
     def interp(
         self,
         coords: Mapping[Hashable, Any] = None,
@@ -64,8 +80,31 @@ class Quantity:
         assume_sorted: bool = True,
         kwargs: Mapping[str, Any] = None,
         **coords_kwargs: Any,
-    ):  # pragma: no cover
-        raise NotImplementedError
+    ):
+        ...
+
+    def item(self, *args):
+        ...
+
+    def rename(
+        self,
+        new_name_or_name_dict: Union[Hashable, Mapping[Any, Hashable]] = None,
+        **names: Hashable,
+    ):  # NB "Quantity" here offends mypy
+        ...
+
+    def sel(
+        self,
+        indexers: Mapping[Any, Any] = None,
+        method: str = None,
+        tolerance=None,
+        drop: bool = False,
+        **indexers_kwargs: Any,
+    ) -> "Quantity":
+        ...
+
+    def to_numpy(self) -> np.ndarray:
+        ...
 
     # Internal methods
 

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -64,18 +64,18 @@ class Quantity:
 
     # Type hints for mypy in downstream applications
     def __len__(self) -> int:
-        ...
+        ...  # pragma: no cover
 
     def __truediv__(self, other) -> "Quantity":
-        ...
+        ...  # pragma: no cover
 
     @property
     def attrs(self) -> Dict[Any, Any]:
-        ...
+        ...  # pragma: no cover
 
     @property
     def coords(self) -> xarray.core.coordinates.DataArrayCoordinates:
-        ...
+        ...  # pragma: no cover
 
     def interp(
         self,
@@ -85,17 +85,17 @@ class Quantity:
         kwargs: Mapping[str, Any] = None,
         **coords_kwargs: Any,
     ):
-        ...
+        ...  # pragma: no cover
 
     def item(self, *args):
-        ...
+        ...  # pragma: no cover
 
     def rename(
         self,
         new_name_or_name_dict: Union[Hashable, Mapping[Any, Hashable]] = None,
         **names: Hashable,
     ):  # NB "Quantity" here offends mypy
-        ...
+        ...  # pragma: no cover
 
     def sel(
         self,
@@ -105,10 +105,10 @@ class Quantity:
         drop: bool = False,
         **indexers_kwargs: Any,
     ) -> "Quantity":
-        ...
+        ...  # pragma: no cover
 
     def to_numpy(self) -> np.ndarray:
-        ...
+        ...  # pragma: no cover
 
     # Internal methods
 

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import Any, Hashable, Mapping, Tuple, Union
+from typing import Any, Dict, Hashable, Mapping, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -66,7 +66,7 @@ class Quantity:
         ...
 
     @property
-    def attrs(self) -> dict[Any, Any]:
+    def attrs(self) -> Dict[Any, Any]:
         ...
 
     @property

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -58,6 +58,10 @@ class Quantity:
             "_unit", pint.get_application_registry().dimensionless
         )
 
+    @units.setter
+    def units(self, value):
+        self.attrs["_unit"] = pint.get_application_registry().Unit(value)
+
     # Type hints for mypy in downstream applications
     def __len__(self) -> int:
         ...

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Hashable, Mapping, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import pint
 import sparse
 import xarray as xr
 from xarray.core import dtypes
@@ -158,13 +157,6 @@ class SparseDataArray(OverrideItem, xr.DataArray, Quantity):
         """Convert a pandas.Series into a SparseDataArray."""
         # Call the parent method always with sparse=True, then re-wrap
         return xr.DataArray.from_series(obj, sparse=True)._sda.convert()
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set the units of the Quantity."""
-        if name == "units":
-            self.attrs["_unit"] = pint.get_application_registry().Unit(value)
-        else:
-            super().__setattr__(name, value)
 
     def ffill(self, dim: Hashable, limit: int = None):
         """Override :meth:`~xarray.DataArray.ffill` to auto-densify."""

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -181,7 +181,12 @@ class SparseDataArray(OverrideItem, xr.DataArray, Quantity):
             raise ValueError("can only convert an array of size 1 to a Python scalar")
 
     def sel(
-        self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
+        self,
+        indexers: Mapping[Any, Any] = None,
+        method: str = None,
+        tolerance=None,
+        drop: bool = False,
+        **indexers_kwargs: Any,
     ) -> "SparseDataArray":
         """Return a new array by selecting labels along the specified dim(s).
 


### PR DESCRIPTION
This improves typing of the Quantity and Computer classes, for the benefit of type checking in downstream code.

Also:
- IAMconsortium/pyam#589 pinned `pint <= 0.17`, when the latest is 0.18. When installed on the CI runner (by `genno[tests] -> genno[compat] -> genno[pyam]`). Update the workflow to override.
- Partly addresses #38, though tests in genno proper are still needed.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
