### PR TITLE
Improve typing of arithmetic, Quantity.shift(), Quantity.to_dataframe()

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,11 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add explicit implementations of :meth:`~.object.__radd__`, :meth:`~.object.__rmul__`, :meth:`~.object.__rsub__` and :meth:`~.object.__rtruediv__` for e.g. ``4.2 * Quantity(...)`` (:pull:`55`)
+- Improve typing of :meth:`.Quantity.shift` (:pull:`55`)
 
 v1.9.1 (2022-01-27)
 ===================

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -423,7 +423,7 @@ def pow(a, b):
     if isinstance(a, AttrSeries):
         result = a ** b.align_levels(a)
     else:
-        result = a ** b
+        result = a**b
 
     result.attrs["_unit"] = (
         a.attrs["_unit"] ** unit_exponent

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Any, Hashable, Iterable, Mapping, Union
+from typing import Any, Hashable, Iterable, List, Mapping, Union
 
 import numpy as np
 import pandas as pd
@@ -462,7 +462,7 @@ class AttrSeries(pd.Series, Quantity):
         return self.reorder_levels(dims)
 
     def to_dataframe(
-        self, name: Hashable = None, dim_order: list[Hashable] = None
+        self, name: Hashable = None, dim_order: List[Hashable] = None
     ) -> pd.DataFrame:
         """Like :meth:`xarray.DataArray.to_dataframe`."""
         if dim_order is not None:

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -461,8 +461,14 @@ class AttrSeries(pd.Series, Quantity):
         """Like :meth:`xarray.DataArray.transpose`."""
         return self.reorder_levels(dims)
 
-    def to_dataframe(self):
+    def to_dataframe(
+        self, name: Hashable = None, dim_order: list[Hashable] = None
+    ) -> pd.DataFrame:
         """Like :meth:`xarray.DataArray.to_dataframe`."""
+        if dim_order is not None:
+            raise NotImplementedError("dim_order arg to to_dataframe()")
+
+        self.name = name or self.name or "value"  # type: ignore
         return self.to_frame()
 
     def to_series(self):

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -62,29 +62,20 @@ class Quantity:
     def units(self, value):
         self.attrs["_unit"] = pint.get_application_registry().Unit(value)
 
-    # Convenience and typing
-    def __radd__(self, other: Union[float, int]):
-        if not isinstance(other, (float, int)):
-            return NotImplemented
-        return Quantity(other) + self  # type: ignore [operator]
-
-    def __rmul__(self, other: Union[float, int]):
-        if not isinstance(other, (float, int)):
-            return NotImplemented
-        return Quantity(other) * self  # type: ignore [operator]
-
-    def __rsub__(self, other: Union[float, int]):
-        if not isinstance(other, (float, int)):
-            return NotImplemented
-        return Quantity(other) - self  # type: ignore [operator]
-
-    def __rtruediv__(self, other: Union[float, int]):
-        if not isinstance(other, (float, int)):
-            return NotImplemented
-        return Quantity(other) / self
-
     # Type hints for mypy in downstream applications
     def __len__(self) -> int:
+        ...  # pragma: no cover
+
+    def __radd__(self, other):
+        ...  # pragma: no cover
+
+    def __rmul__(self, other):
+        ...  # pragma: no cover
+
+    def __rsub__(self, other):
+        ...  # pragma: no cover
+
+    def __rtruediv__(self, other):
         ...  # pragma: no cover
 
     def __truediv__(self, other) -> "Quantity":

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -68,11 +68,6 @@ class Quantity:
             return NotImplemented
         return Quantity(other) + self  # type: ignore [operator]
 
-    def __rtruediv__(self, other: Union[float, int]):
-        if not isinstance(other, (float, int)):
-            return NotImplemented
-        return Quantity(other) / self
-
     def __rmul__(self, other: Union[float, int]):
         if not isinstance(other, (float, int)):
             return NotImplemented
@@ -82,6 +77,11 @@ class Quantity:
         if not isinstance(other, (float, int)):
             return NotImplemented
         return Quantity(other) - self  # type: ignore [operator]
+
+    def __rtruediv__(self, other: Union[float, int]):
+        if not isinstance(other, (float, int)):
+            return NotImplemented
+        return Quantity(other) / self
 
     # Type hints for mypy in downstream applications
     def __len__(self) -> int:

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -62,6 +62,27 @@ class Quantity:
     def units(self, value):
         self.attrs["_unit"] = pint.get_application_registry().Unit(value)
 
+    # Convenience and typing
+    def __radd__(self, other: Union[float, int]):
+        if not isinstance(other, (float, int)):
+            return NotImplemented
+        return Quantity(other) + self  # type: ignore [operator]
+
+    def __rtruediv__(self, other: Union[float, int]):
+        if not isinstance(other, (float, int)):
+            return NotImplemented
+        return Quantity(other) / self
+
+    def __rmul__(self, other: Union[float, int]):
+        if not isinstance(other, (float, int)):
+            return NotImplemented
+        return Quantity(other) * self  # type: ignore [operator]
+
+    def __rsub__(self, other: Union[float, int]):
+        if not isinstance(other, (float, int)):
+            return NotImplemented
+        return Quantity(other) - self  # type: ignore [operator]
+
     # Type hints for mypy in downstream applications
     def __len__(self) -> int:
         ...  # pragma: no cover

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -107,6 +107,14 @@ class Quantity:
     ) -> "Quantity":
         ...  # pragma: no cover
 
+    def shift(
+        self,
+        shifts: Mapping[Hashable, int] = None,
+        fill_value: Any = None,
+        **shifts_kwargs: int,
+    ):  # NB "Quantity" here offends mypy
+        ...  # pragma: no cover
+
     def to_numpy(self) -> np.ndarray:
         ...  # pragma: no cover
 

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Hashable, Mapping, Sequence, Tuple, Union
+from typing import Any, Dict, Hashable, List, Mapping, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -201,7 +201,7 @@ class SparseDataArray(OverrideItem, xr.DataArray, Quantity):
             )
 
     def to_dataframe(
-        self, name: Hashable = None, dim_order: list[Hashable] = None
+        self, name: Hashable = None, dim_order: List[Hashable] = None
     ) -> pd.DataFrame:
         """Convert this array and its coords into a :class:`~xarray.DataFrame`.
 

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -200,12 +200,16 @@ class SparseDataArray(OverrideItem, xr.DataArray, Quantity):
                 ._sda.convert()
             )
 
-    def to_dataframe(self, name=None):
+    def to_dataframe(
+        self, name: Hashable = None, dim_order: list[Hashable] = None
+    ) -> pd.DataFrame:
         """Convert this array and its coords into a :class:`~xarray.DataFrame`.
 
         Overrides :meth:`~xarray.DataArray.to_dataframe`.
         """
-        return self.to_series().to_frame(name)
+        if dim_order is not None:
+            raise NotImplementedError("dim_order arg to to_dataframe()")
+        return self.to_series().to_frame(name or self.name or "value")
 
     def to_series(self) -> pd.Series:
         """Convert this array into a :class:`~pandas.Series`.

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -394,7 +394,7 @@ def test_add_product(ureg):
     assert key == "x squared:t-y"
 
     # Product has the expected value
-    assert_qty_equal(Quantity(x * x, units=ureg.kilogram ** 2), c.get(key))
+    assert_qty_equal(Quantity(x * x, units=ureg.kilogram**2), c.get(key))
 
     # add('product', ...) works
     key = c.add("product", "x_squared", "x", "x", sums=True)

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -279,8 +279,11 @@ class TestQuantity:
         # "value" is used as a column name
         assert ["value"] == result.columns
 
-        # Explicitly passed name produces
+        # Explicitly passed name produces a named column
         assert ["foo"] == a.to_dataframe("foo").columns
+
+        with pytest.raises(NotImplementedError):
+            a.to_dataframe(dim_order=["foo", "bar"])
 
     def test_to_series(self, a):
         """Test .to_series() on child classes, and Quantity.from_series."""

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -272,7 +272,15 @@ class TestQuantity:
 
     def test_to_dataframe(self, a):
         """Test Quantity.to_dataframe()."""
-        assert isinstance(a.to_dataframe(), pd.DataFrame)
+        # Returns pd.DataFrame
+        result = a.to_dataframe()
+        assert isinstance(result, pd.DataFrame)
+
+        # "value" is used as a column name
+        assert ["value"] == result.columns
+
+        # Explicitly passed name produces
+        assert ["foo"] == a.to_dataframe("foo").columns
 
     def test_to_series(self, a):
         """Test .to_series() on child classes, and Quantity.from_series."""

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -1,5 +1,6 @@
 """Tests for genno.quantity."""
 import logging
+import operator
 import re
 
 import pandas as pd
@@ -7,6 +8,7 @@ import pint
 import pytest
 import xarray as xr
 from numpy import nan
+from pytest import param
 
 from genno import Computer, Quantity, computations
 from genno.core.attrseries import AttrSeries
@@ -290,3 +292,14 @@ class TestQuantity:
         # Can be set to dimensionless
         a.units = ""
         assert a.units.dimensionless
+
+    @pytest.mark.parametrize(
+        "op", [operator.add, operator.truediv, operator.mul, operator.sub]
+    )
+    @pytest.mark.parametrize("type_", [int, float, param(str, marks=pytest.mark.xfail)])
+    def test_arithmetic(self, op, type_, a):
+        """Quantity can be added to int or float."""
+        result = op(type_(4.2), a)
+
+        assert (2,) == result.shape
+        assert a.dtype == result.dtype

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -302,7 +302,7 @@ class TestQuantity:
         assert a.units.dimensionless
 
     @pytest.mark.parametrize(
-        "op", [operator.add, operator.truediv, operator.mul, operator.sub]
+        "op", [operator.add, operator.mul, operator.sub, operator.truediv]
     )
     @pytest.mark.parametrize("type_", [int, float, param(str, marks=pytest.mark.xfail)])
     def test_arithmetic(self, op, type_, a):

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -305,7 +305,7 @@ def test_pow(ureg):
     result = computations.pow(A, 2)
 
     # Expected units
-    assert ureg.kg ** 2 == result.attrs["_unit"]
+    assert ureg.kg**2 == result.attrs["_unit"]
 
     # 2D ** 1D
     B = random_qty(dict(y=3))
@@ -347,9 +347,9 @@ def test_product0():
     "dims, exp_size",
     (
         # Some overlapping dimensions
-        ((dict(a=2, b=2, c=2, d=2), dict(b=2, c=2, d=2, e=2, f=2)), 2 ** 6),
+        ((dict(a=2, b=2, c=2, d=2), dict(b=2, c=2, d=2, e=2, f=2)), 2**6),
         # 1D with disjoint dimensions ** 3 = 3D
-        ((dict(a=2), dict(b=2), dict(c=2)), 2 ** 3),
+        ((dict(a=2), dict(b=2), dict(c=2)), 2**3),
         # 2D × scalar × scalar = 2D
         ((dict(a=2, b=2), dict(), dict()), 4),
         # scalar × 1D × scalar = 1D


### PR DESCRIPTION
This adds explicit arithmetic so that:
```python
x = 4.2 * Quantity(…)
```
…works _and_ satisfies mypy.

Also:
- Improve typing of `Quantity.shift()`.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- [x] Update doc/whatsnew.rst
