### PR TITLE
Remove workaround for `pyam` pin of `pint` in pytest workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -80,13 +80,10 @@ jobs:
     - name: Install Python package and dependencies
       run: |
         pip install --editable .[docs,tests]
-        # pyam-iamc (IAMconsortium/pyam#651) forces pint < 0.19; override
-        pip install --upgrade pint
         # TEMPORARY downgrade xarray pending khaeru/genno#67
         pip install xarray!=2022.6.0
         # TEMPORARY downgrade matplotlib pending has2k1/plotnine#619
         pip install "matplotlib<3.6.0"
-
 
     - name: Run test suite using pytest
       run: pytest genno --trace-config --verbose --cov-report=xml --cov-report=term --color=yes


### PR DESCRIPTION
This PR removes the `pint` upgrade in the pytest.yaml workflow, which got introduced due to https://github.com/IAMconsortium/pyam/pull/589 and can be removed now due to https://github.com/IAMconsortium/pyam/pull/640.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- ~Update doc/whatsnew.rst~
