### PR TITLE
Return to latest pint in pytest CI workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -78,9 +78,9 @@ jobs:
       run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Install Python package and dependencies
-      # pyam-iamc (IAMconsortium/pyam#589) forces pint 0.17; override
       run: |
         pip install --editable .[docs,tests]
+        # pyam-iamc (IAMconsortium/pyam#651) forces pint < 0.19; override
         pip install --upgrade pint
 
     - name: Run test suite using pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -78,14 +78,10 @@ jobs:
       run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Install Python package and dependencies
+      # pyam-iamc (IAMconsortium/pyam#589) forces pint 0.17; override
       run: |
         pip install --editable .[docs,tests]
-
-    - name: Specify version of pint
-      if: matrix.python-version != '3.7'
-      run: |
-        # Branch for with https://github.com/hgrecco/pint/pull/1508
-        pip install --upgrade git+https://github.com/khaeru/pint.git@issue/1498#egg=pint
+        pip install --upgrade pint
 
     - name: Run test suite using pytest
       run: pytest genno --trace-config --verbose --cov-report=xml --cov-report=term --color=yes


### PR DESCRIPTION
Pint 0.19.2 was released, so the workaround to the pytest CI workflow introduced #60 is no longer needed.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- ~Update doc/whatsnew.rst~
