### PR TITLE
Improve `aggregate()`, `sum()`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,22 +13,26 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
-      # Uncomment and set this to match the "Latest version testable on GitHub
-      # Actions" in pytest.yaml, if that is not the default used by setup-python
-      # with:
-      #   python-version: "3.9"
+    - uses: actions/setup-python@v4
+      with:
+        # If the "Latest version testable on GitHub Actions" in pytest.yaml
+        # is not the latest 3.x stable version, adjust here to match:
+        python-version: "3.x"
+
+    - name: Upgrade pip, wheel, setuptools-scm
+      id: pip
+      run: |
+        python -m pip install --upgrade pip wheel setuptools-scm
+        # Locate pip cache directory
+        echo "::set-output name=cache-dir::$(pip cache dir)"
 
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
+        path: ${{ steps.pip.outputs.cache-dir }}
         key: lint-${{ runner.os }}
-
-    - name: Upgrade pip, wheel, setuptools-scm
-      run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Check "black" code style
       run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
-      # Uncomment and set this to match the "Latest version testable on GitHub
-      # Actions" in pytest.yaml, if that is not the default used by setup-python
-      # with:
-      #   python-version: "3.9"
+    - uses: actions/setup-python@v4
+      with:
+        # If the "Latest version testable on GitHub Actions" in pytest.yaml
+        # is not the latest 3.x stable version, adjust here to match:
+        python-version: "3.x"
 
     - name: Cache Python packages
       uses: actions/cache@v3

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,8 +21,7 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - "3.7"  # Earliest version supported by genno; matches xarray/setup.cfg
-        - "3.8"
+        - "3.8"  # Earliest version supported by genno; matches xarray/setup.cfg
         - "3.9"
         - "3.10" # Latest release / latest supported by genno / testable on GHA
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,11 +33,6 @@ jobs:
         # for genno. Exclude these versions from CI.
         # - "3.11.0-alpha.2"  # Development version
 
-        exclude:
-        # JPype1 binary wheels are not available for this combination
-        - os: windows-latest
-          python-version: "3.10"
-
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -45,37 +45,37 @@ jobs:
 
     steps:
     - name: Cancel previous runs that have not completed
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.10.0
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: ${{ env.depth }}
 
     - name: Fetch tags (for setuptools-scm)
       run: git fetch --tags --depth=${{ env.depth }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Locate pip cache directory
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
+    - name: Upgrade pip, wheel, setuptools-scm
+      id: pip
+      run: |
+        python -m pip install --upgrade pip wheel setuptools-scm
+        # Locate pip cache directory
+        echo "::set-output name=cache-dir::$(pip cache dir)"
 
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: ${{ steps.pip-cache.outputs.dir }}
+        path: ${{ steps.pip.outputs.cache-dir }}
         key: ${{ matrix.os }}-py${{ matrix.python-version }}
         restore-keys: |
           ${{ matrix.os }}-
 
     - uses: ts-graphviz/setup-graphviz@v1
-
-    - name: Upgrade pip, wheel, setuptools-scm
-      run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Install Python package and dependencies
       run: |
@@ -94,4 +94,4 @@ jobs:
       run: make html
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -317,7 +317,9 @@ Computations
 
    .. autosummary::
       apply_units
+      assign_units
       concat
+      convert_units
       relabel
       rename_dims
       select

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,18 +41,13 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # builtin themes.
 html_theme = "sphinx_rtd_theme"
 
-# Add any paths that contain custom static files (such as style sheets) here, relative
-# to this directory. They are copied after the builtin static files, so a file named
-# "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
-
 
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
 
 extlinks = {
-    "issue": ("https://github.com/khaeru/genno/issues/%s", "#"),
-    "pull": ("https://github.com/khaeru/genno/pull/%s", "PR #"),
-    "gh-user": ("https://github.com/%s", "@"),
+    "issue": ("https://github.com/khaeru/genno/issues/%s", "#%s"),
+    "pull": ("https://github.com/khaeru/genno/pull/%s", "PR #%s"),
+    "gh-user": ("https://github.com/%s", "@%s"),
 }
 extlinks_detect_hardcoded_links = False
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,11 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Following pandas (v1.4.0, released 2022-01-22) and xarray (v0.21.0, released 2022-01-27), support for Python 3.7 is dropped.
+  genno supports and is tested on Python 3.8 and newer.
 
 v1.13.0 (2022-08-17)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -9,7 +9,9 @@ What's new
 Next release
 ============
 
-- Following pandas (v1.4.0, released 2022-01-22) and xarray (v0.21.0, released 2022-01-27), support for Python 3.7 is dropped.
+- Add new computations :func:`.assign_units` and :func:`.convert_units`.
+  These have simpler behaviour than :func:`.apply_units` and should be preferred in most situations (:pull:`72`).
+- Following pandas (v1.4.0, released 2022-01-22) and xarray (v0.21.0, released 2022-01-27), support for Python 3.7 is dropped (:pull:`72`).
   genno supports and is tested on Python 3.8 and newer.
 
 v1.13.0 (2022-08-17)

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -20,9 +20,11 @@ __all__ = [
     "add",
     "aggregate",
     "apply_units",
+    "assign_units",
     "broadcast_map",
     "combine",
     "concat",
+    "convert_units",
     "disaggregate_shares",
     "div",
     "group_sum",
@@ -153,18 +155,25 @@ def _unit_args(qty, units):
     return *result, getattr(result[1], "dimensionality", {}), result[0].Unit(units)
 
 
-def apply_units(qty: Quantity, units: UnitLike, quiet=False) -> Quantity:
+def apply_units(qty: Quantity, units: UnitLike) -> Quantity:
     """Apply `units` to `qty`.
 
-    Logs on level ``WARNING`` if *qty* already has existing units.
+    If `qty` has existing units…
+
+    - …with compatible dimensionality to `units`, the magnitudes are adjusted, i.e.
+      behaves like :func:`convert_units`.
+    - …with incompatible dimensionality to `units`, the units attribute is overwritten
+      and magnitudes are not changed, i.e. like :func:`assign_units`, with a log message
+      on level ``WARNING``.
+
+    To avoid ambiguities between the two cases, use :func:`convert_units` or
+    :func:`assign_units` instead.
 
     Parameters
     ----------
-    qty : .Quantity
+    qty : Quantity
     units : str or pint.Unit
-        Units to apply to *qty*
-    quiet : bool, optional
-        If :obj:`True` log on level ``DEBUG``.
+        Units to apply to `qty`.
     """
     registry, existing, existing_dims, new_units = _unit_args(qty, units)
 
@@ -193,9 +202,9 @@ def assign_units(qty: Quantity, units: UnitLike) -> Quantity:
 
     Parameters
     ----------
-    qty : .Quantity
+    qty : Quantity
     units : str or pint.Unit
-        Units to apply to *qty*
+        Units to assign to `qty`.
     """
     registry, existing, existing_dims, new_units = _unit_args(qty, units)
 
@@ -216,13 +225,18 @@ def assign_units(qty: Quantity, units: UnitLike) -> Quantity:
 
 
 def convert_units(qty: Quantity, units: UnitLike) -> Quantity:
-    """Convert `qty` from its current units to `units`.
+    """Convert magnitude of `qty` from its current units to `units`.
+
+    Parameters
+    ----------
+    qty : Quantity
+    units : str or pint.Unit
+        Units to assign to `qty`.
 
     Raises
     ------
     ValueError
-        if `units` does not match the dimensionality of the current units of
-
+        if `units` does not match the dimensionality of the current units of `qty`.
     """
     registry, existing, existing_dims, new_units = _unit_args(qty, units)
 

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -154,7 +154,7 @@ def _unit_args(qty, units):
 
 
 def apply_units(qty: Quantity, units: UnitLike, quiet=False) -> Quantity:
-    """Apply *units* to *qty*.
+    """Apply `units` to `qty`.
 
     Logs on level ``WARNING`` if *qty* already has existing units.
 

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -120,7 +120,7 @@ def aggregate(quantity, groups: Mapping[Hashable, Mapping], keep: bool):
 
         # Aggregate each group
         for group, members in dim_groups.items():
-            if group in values[0].coords[dim]:
+            if keep and group in values[0].coords[dim]:
                 log.warning(
                     f"{dim}={group!r} is already present in quantity {quantity.name!r} "
                     "with keep=True"

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -108,10 +108,15 @@ class Quantity:
         ...  # pragma: no cover
 
     def assign_coords(
-        self,
-        coords: Optional[Mapping[Any, Any]] = None,
-        **coords_kwargs: Any,
+        self, coords: Optional[Mapping[Any, Any]] = None, **coords_kwargs: Any
     ) -> "Quantity":
+        ...  # pragma: no cover
+
+    def copy(
+        self,
+        deep: bool = True,
+        data: Any = None,
+    ):  # NB "Quantity" here offends mypy
         ...  # pragma: no cover
 
     def expand_dims(

--- a/genno/testing.py
+++ b/genno/testing.py
@@ -191,6 +191,8 @@ def assert_logs(caplog, message_or_messages=None, at_level=None):
     at_level : int, optional
         Messages must appear on 'genno' or a sub-logger with at least this level.
     """
+    __tracebackhide__ = True
+
     # Wrap a string in a list
     expected = (
         [message_or_messages]

--- a/genno/testing.py
+++ b/genno/testing.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 from copy import copy
 from functools import partial
-from itertools import chain, zip_longest
+from itertools import chain
 from typing import Dict
 
 import numpy as np
@@ -19,7 +19,7 @@ from genno import Computer, Key, Quantity
 log = logging.getLogger(__name__)
 
 
-def add_large_data(c: Computer, num_params, N_dims=6):
+def add_large_data(c: Computer, num_params, N_dims=6, N_data=0):
     """Add nodes to `c` that return large-ish data.
 
     The result is a matrix wherein the Cartesian product of all the keys is very large—
@@ -28,8 +28,9 @@ def add_large_data(c: Computer, num_params, N_dims=6):
     by :class:`np.array`.
     """
     # Dimensions and their lengths (Fibonacci numbers)
-    dims = "abcdefg"[:N_dims]
-    sizes = [233, 377, 610, 987, 1597, 2584, 4181][:N_dims]
+    dims = "abcdefghijk"[:N_dims]
+    sizes = [233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711, 28657][:N_dims]
+    N_data = max(int(N_data), sizes[-1])
 
     # commented; for debugging
     # # Output something like "True: 2584 values / 2.182437e+17 = 1.184e-12% full"
@@ -43,21 +44,38 @@ def add_large_data(c: Computer, num_params, N_dims=6):
     #     + f": {max(sizes)} values / {total:3e} = {100 * max(sizes) / total:.3e}% full"
     # )
 
-    # Names like f_0000 ... f_1596 along each dimension
-    coords = []
+    # Names like f_00000 ... f_01596 along each dimension
+    dtypes = {"value": float}
     for d, N in zip(dims, sizes):
-        coords.append([f"{d}_{i:04d}" for i in range(N)])
+        categories = [f"{d}_{i:05d}" for i in range(N)]
         # Add to Computer
-        c.add(d, quote(coords[-1]))
+        c.add(d, quote(categories))
+        # Create a categorical dtype
+        dtypes[d] = pd.CategoricalDtype(categories)
+
+    # Random generator
+    rng = np.random.default_rng()
 
     def get_large_quantity(name):
         """Make a DataFrame containing each label in *coords* ≥ 1 time."""
-        values = list(zip_longest(*coords, np.random.rand(max(sizes))))
-        log.info(f"{len(values)} values")
+        log.info(f"{N_data} values")
+
+        # Allocate memory for the data frame using the given data types
+        df = pd.DataFrame(
+            index=pd.RangeIndex(N_data), columns=list(dims) + ["value"]
+        ).astype(dtypes)
+
+        # Fill values
+        df.loc[:, "value"] = rng.random(N_data)
+
+        # Fill labels
+        for d in dims:
+            df.loc[:, d] = pd.Categorical.from_codes(
+                rng.integers(0, len(dtypes[d].categories), N_data), dtype=dtypes[d]
+            )
+
         return Quantity(
-            pd.DataFrame(values, columns=list(dims) + ["value"])
-            .ffill()
-            .set_index(list(dims)),
+            df.set_index(list(dims)),
             units=pint.get_application_registry().kilogram,
             name=name,
         )

--- a/genno/testing.py
+++ b/genno/testing.py
@@ -70,7 +70,7 @@ def add_large_data(c: Computer, num_params, N_dims=6, N_data=0):
 
         # Fill labels
         for d in dims:
-            df.loc[:, d] = pd.Categorical.from_codes(
+            df[d] = pd.Categorical.from_codes(
                 rng.integers(0, len(dtypes[d].categories), N_data), dtype=dtypes[d]
             )
 

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -2,7 +2,9 @@
 import pandas as pd
 import pytest
 
+from genno import Computer
 from genno.core.attrseries import AttrSeries
+from genno.testing import add_large_data
 
 
 @pytest.fixture
@@ -58,6 +60,34 @@ def test_sum(foo, bar):
     # Sum with wrong dim raises ValueError
     with pytest.raises(ValueError):
         bar.sum("b")
+
+    # Index with duplicate entries
+    _baz = pd.DataFrame(
+        [
+            ["a1", "b1", "c1", 1.0],
+            ["a1", "b1", "c1", 2.0],
+            ["a2", "b2", "c3", 3.0],
+            ["a2", "b2", "c4", 4.0],
+            ["a3", "b3", "c5", 5.0],
+        ],
+        columns=["a", "b", "c", "value"],
+    )
+    # Fails with v1.13.0 AttrSeries.sum() using unstack()
+    AttrSeries(_baz.set_index(["a", "b", "c"])["value"]).sum(dim="c")
+
+
+@pytest.mark.skip
+def test_sum_large(N_data=1e7):  # pragma: no cover
+    """Test :meth:`.AttrSeries.sum` for large, sparse data."""
+    # Create a single large AttrSeries
+    c = Computer()
+    add_large_data(c, 1, N_dims=11, N_data=N_data)
+    qty = c.get("q_00")
+
+    # Compute a sum()
+    result = qty.sum(dim=["j", "k"])
+    # print(result)  # DEBUG
+    del result
 
 
 def test_others(foo, bar):

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -264,6 +264,12 @@ class TestQuantity:
         # One quantity fits in memory
         c.get(keys[0])
 
+        if Quantity._get_class() is SparseDataArray:
+            pytest.xfail(
+                reason='"IndexError: Only one-dimensional iterable indices supported." '
+                "in sparse._coo.indexing"
+            )
+
         # All quantities can be multiplied without raising MemoryError
         result = c.get("bigmem")
 

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -49,13 +49,13 @@ def test_add(data, operands, size):
         xr.DataArray(
             np.random.rand(len(t_foo), len(y)), coords=[t_foo, y], dims=["t", "y"]
         ),
-        units=x.attrs["_unit"],
+        units=x.units,
     )
     b = Quantity(
         xr.DataArray(
             np.random.rand(len(t_bar), len(y)), coords=[t_bar, y], dims=["t", "y"]
         ),
-        units=x.attrs["_unit"],
+        units=x.units,
     )
 
     c.add("a:t-y", a)
@@ -265,7 +265,7 @@ def test_div(func, ureg):
 
     result = func(A, B)
     assert ("x", "y", "z") == result.dims
-    assert ureg.Unit("km / hour") == result.attrs["_unit"]
+    assert ureg.Unit("km / hour") == result.units
 
 
 def test_group_sum(ureg):
@@ -461,7 +461,7 @@ def test_pow(ureg):
     result = computations.pow(A, 2)
 
     # Expected units
-    assert ureg.kg**2 == result.attrs["_unit"]
+    assert ureg.kg**2 == result.units
 
     # 2D ** 1D
     B = random_qty(dict(y=3))
@@ -473,7 +473,7 @@ def test_pow(ureg):
         A.sel(x="x1", y="y1").item() ** B.sel(y="y1").item()
         == result.sel(x="x1", y="y1").item()
     )
-    assert ureg.dimensionless == result.attrs["_unit"]
+    assert ureg.dimensionless == result.units
 
     # 2D ** 1D with units
     C = random_qty(dict(y=3), units="km")

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -26,7 +25,7 @@ classifiers =
 
 [options]
 packages = genno
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     dask [array] >= 2.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,12 +72,9 @@ test = pytest
 [tool:pytest]
 addopts = --cov=genno --cov-report=
 
-# Respectively:
-# - .compat.plotnine -> plotnine 0.7.1 -> patsy 0.5.1
-# - .core.sparsedataarray -> sparse 0.11.2 -> numba 0.52.0 -> numpy 1.20
-filterwarnings =
-    ignore:Using or importing the ABCs:DeprecationWarning:patsy
-    ignore:`np.long` is a deprecated alias for `np.compat.long`:DeprecationWarning:numba.core
+
+# Currently unused
+# filterwarnings =
 
 [isort]
 profile = black


### PR DESCRIPTION
- Add new computations `assign_units()`, `convert_units()`
- Use pd.Series.groupby(), instead of .stack() in AttrSeries.sum() to handle larger data without memory issues.
- Remove support for Python 3.7.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
