### PR TITLE
Miscellaneous improvements for 2022-W42

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,5 +47,5 @@ jobs:
     - name: Check typing with mypy
       # Also install packages that provide type hints
       run: |
-        pip install mypy ixmp pytest types-PyYAML "xarray!=2022.6.0"
+        pip install mypy ixmp pytest types-PyYAML xarray
         mypy .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,5 +47,5 @@ jobs:
     - name: Check typing with mypy
       # Also install packages that provide type hints
       run: |
-        pip install mypy ixmp pytest types-PyYAML xarray
+        pip install mypy ixmp pytest types-PyYAML types-setuptools xarray
         mypy .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,16 +22,15 @@ jobs:
         python-version: "3.x"
 
     - name: Upgrade pip, wheel, setuptools-scm
-      id: pip
       run: |
         python -m pip install --upgrade pip wheel setuptools-scm
         # Locate pip cache directory
-        echo "::set-output name=cache-dir::$(pip cache dir)"
+        echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
 
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: ${{ steps.pip.outputs.cache-dir }}
+        path: ${{ env.pip-cache-dir }}
         key: lint-${{ runner.os }}
 
     - name: Check "black" code style

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -76,8 +76,6 @@ jobs:
         pip install --editable .[docs,tests]
         # TEMPORARY downgrade xarray pending khaeru/genno#67
         pip install xarray!=2022.6.0
-        # TEMPORARY downgrade matplotlib pending has2k1/plotnine#619
-        pip install "matplotlib<3.6.0"
 
     - name: Run test suite using pytest
       run: pytest genno --trace-config --verbose --cov-report=xml --cov-report=term --color=yes

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -55,16 +55,16 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Upgrade pip, wheel, setuptools-scm
-      id: pip
+      shell: bash
       run: |
         python -m pip install --upgrade pip wheel setuptools-scm
         # Locate pip cache directory
-        echo "::set-output name=cache-dir::$(pip cache dir)"
+        echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
 
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: ${{ steps.pip.outputs.cache-dir }}
+        path: ${{ env.pip-cache-dir }}
         key: ${{ matrix.os }}-py${{ matrix.python-version }}
         restore-keys: |
           ${{ matrix.os }}-

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Cancel previous runs that have not completed
-      uses: styfle/cancel-workflow-action@0.10.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -74,8 +74,6 @@ jobs:
     - name: Install Python package and dependencies
       run: |
         pip install --editable .[docs,tests]
-        # TEMPORARY downgrade xarray pending khaeru/genno#67
-        pip install xarray!=2022.6.0
 
     - name: Run test suite using pytest
       run: pytest genno --trace-config --verbose --cov-report=xml --cov-report=term --color=yes

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,8 +6,11 @@ What's new
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Fix :meth:`~.AttrSeries.cumprod` for 1-dimensional :class:`.AttrSeries` (:pull:`74`).
+- Adjust for compatibility with pint 0.20 (released 2022-10-25) (:pull:`74`).
 
 v1.14.0 (2022-09-27)
 ====================

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -9,6 +9,7 @@ from typing import Any, Collection, Hashable, Mapping, Optional, Union, cast
 
 import pandas as pd
 import pint
+from xarray.core.types import InterpOptions
 from xarray.core.utils import either_dict_or_kwargs
 
 from genno.core.attrseries import AttrSeries, _multiindex_of
@@ -420,7 +421,7 @@ def group_sum(qty, group, sum):
 def interpolate(
     qty: Quantity,
     coords: Mapping[Hashable, Any] = None,
-    method: str = "linear",
+    method: InterpOptions = "linear",
     assume_sorted: bool = True,
     kwargs: Mapping[str, Any] = None,
     **coords_kwargs: Any,

--- a/genno/config.py
+++ b/genno/config.py
@@ -286,7 +286,7 @@ def units(c: Computer, info):
         registry.define(defs)
     except KeyError:
         pass
-    except pint.DefinitionSyntaxError as e:
+    except (TypeError, pint.DefinitionSyntaxError, pint.RedefinitionError) as e:
         log.warning(e)
     else:
         log.info(f"Apply global unit definitions {defs}")

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -1,18 +1,7 @@
 import logging
 import warnings
 from functools import partial
-from typing import (
-    Any,
-    Hashable,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Hashable, Iterable, List, Mapping, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -21,6 +10,7 @@ import xarray as xr
 from xarray.core.utils import either_dict_or_kwargs
 
 from genno.core.quantity import Quantity
+from genno.core.types import Dims
 
 log = logging.getLogger(__name__)
 
@@ -427,15 +417,18 @@ class AttrSeries(pd.Series, Quantity):
 
     def sum(
         self,
-        dim: Optional[Union[Hashable, Sequence[Hashable]]] = None,
+        dim: Dims = None,
         # Signature from xarray.DataArray
         # *,
-        # skipna: bool | None = None,
-        # min_count: int | None = None,
+        skipna: Optional[bool] = None,
+        min_count: Optional[int] = None,
         keep_attrs: Optional[bool] = None,
         **kwargs: Any,
     ) -> "AttrSeries":
         """Like :meth:`xarray.DataArray.sum`."""
+        if skipna is not None or min_count is not None:
+            raise NotImplementedError
+
         if dim is None or isinstance(dim, Hashable):
             dim = tuple(filter(None, (dim,)))
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -137,14 +137,12 @@ class AttrSeries(pd.Series, Quantity):
         """Like :meth:`xarray.DataArray.cumprod`."""
         if axis:
             log.info(f"{self.__class__.__name__}.cumprod(…, axis=…) is ignored")
+        if skipna is None:
+            skipna = self.dtype == float
 
-        return self.__class__(
-            self.unstack(dim)
-            .cumprod(axis=1, skipna=skipna, **kwargs)
-            .stack()
-            .reorder_levels(self.dims),
-            attrs=self.attrs,
-        )
+        # Group on dimensions other than `dim`
+        result = self._maybe_groupby(dim).cumprod(skipna=skipna, **kwargs)
+        return AttrSeries(result, attrs=self.attrs)
 
     @property
     def dims(self) -> Tuple[Hashable, ...]:
@@ -440,16 +438,7 @@ class AttrSeries(pd.Series, Quantity):
             )
 
         # Create the object on which to .sum()
-        if len(dim) in (0, len(self.index.names)):
-            obj = cast(pd.Series, super())
-        else:
-            # Group on dimensions other than `dim`
-            obj = self.groupby(
-                list(filter(lambda d: d not in dim, self.index.names)),  # type: ignore
-                observed=True,
-            )
-
-        return AttrSeries(obj.sum(**kwargs), attrs=self.attrs)
+        return AttrSeries(self._maybe_groupby(dim).sum(**kwargs), attrs=self.attrs)
 
     def squeeze(self, dim=None, *args, **kwargs):
         """Like :meth:`xarray.DataArray.squeeze`."""
@@ -547,3 +536,18 @@ class AttrSeries(pd.Series, Quantity):
 
         # Reorder, if that would do anything
         return result.reorder_levels(order) if len(order) > 1 else result
+
+    def _maybe_groupby(self, dim):
+        """Return an object for operations along dimension(s) `dim`.
+
+        If `dim` is a subset of :attr:`dims`, returns a SeriesGroupBy object along the
+        other dimensions.
+        """
+        if len(set(dim)) in (0, len(self.index.names)):
+            return cast(pd.Series, super())
+        else:
+            # Group on dimensions other than `dim`
+            return self.groupby(
+                list(filter(lambda d: d not in dim, self.index.names)),  # type: ignore
+                observed=True,
+            )

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -1,10 +1,13 @@
 from functools import update_wrapper
-from typing import Any, Dict, Hashable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Hashable, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import pint
 import xarray
+from xarray.core.types import InterpOptions
+
+from .types import Dims
 
 #: Name of the class used to implement :class:`.Quantity`.
 CLASS = "AttrSeries"
@@ -108,8 +111,10 @@ class Quantity:
         ...  # pragma: no cover
 
     def assign_coords(
-        self, coords: Optional[Mapping[Any, Any]] = None, **coords_kwargs: Any
-    ) -> "Quantity":
+        self,
+        coords: Optional[Mapping[Any, Any]] = None,
+        **coords_kwargs: Any,
+    ):
         ...  # pragma: no cover
 
     def copy(
@@ -129,9 +134,9 @@ class Quantity:
 
     def interp(
         self,
-        coords: Mapping[Hashable, Any] = None,
-        method: str = "linear",
-        assume_sorted: bool = True,
+        coords: Mapping[Any, Any] = None,
+        method: InterpOptions = "linear",
+        assume_sorted: bool = False,
         kwargs: Mapping[str, Any] = None,
         **coords_kwargs: Any,
     ):
@@ -167,14 +172,14 @@ class Quantity:
 
     def sum(
         self,
-        dim: Optional[Union[Hashable, Sequence[Hashable]]] = None,
+        dim: Dims = None,
         # Signature from xarray.DataArray
-        # *,
-        # skipna: bool | None = None,
-        # min_count: int | None = None,
+        *,
+        skipna: Optional[bool] = None,
+        min_count: Optional[int] = None,
         keep_attrs: Optional[bool] = None,
         **kwargs: Any,
-    ) -> "Quantity":
+    ):  # NB "Quantity" here offends mypy
         ...  # pragma: no cover
 
     def to_numpy(self) -> np.ndarray:

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Hashable, List, Mapping, Sequence, Tuple, Union
+from typing import Any, Dict, Hashable, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -205,7 +205,7 @@ class SparseDataArray(OverrideItem, xr.DataArray, Quantity):
             )
 
     def to_dataframe(
-        self, name: Hashable = None, dim_order: List[Hashable] = None
+        self, name: Optional[Hashable] = None, dim_order: Sequence[Hashable] = None
     ) -> pd.DataFrame:
         """Convert this array and its coords into a :class:`~xarray.DataFrame`.
 

--- a/genno/core/types.py
+++ b/genno/core/types.py
@@ -1,0 +1,7 @@
+from typing import Hashable, Iterable, Union
+
+# Duplicating xarray 2022.10.0
+Dims = Union[str, Iterable[Hashable], None]
+
+
+__all__ = ["Dims"]

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -82,6 +82,9 @@ def test_sum(foo, bar):
     # Fails with v1.13.0 AttrSeries.sum() using unstack()
     AttrSeries(_baz.set_index(["a", "b", "c"])["value"]).sum(dim="c")
 
+    with pytest.raises(NotImplementedError):
+        bar.sum("a", skipna=False)
+
 
 @pytest.mark.skip
 def test_sum_large(N_data=1e7):  # pragma: no cover

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -15,7 +15,14 @@ def foo():
 
 @pytest.fixture
 def bar():
+    """A 1-dimensional quantity."""
     yield AttrSeries([0, 1], index=pd.Index(["a1", "a2"], name="a"))
+
+
+def test_cumprod(bar):
+    """AttrSeries.cumprod works with 1-dimensional quantities."""
+    result = (1.1 + bar).cumprod("a")
+    assert ("a",) == result.dims
 
 
 def test_interp(foo):

--- a/genno/tests/test_core.py
+++ b/genno/tests/test_core.py
@@ -1,5 +1,3 @@
-import re
-
 from genno import configure
 from genno.util import REPLACE_UNITS
 
@@ -7,7 +5,7 @@ from genno.util import REPLACE_UNITS
 def test_configure_units(caplog):
     # Warning is logged on invalid definitions
     configure(units=dict(define="0 = [0] * %"))
-    assert re.match(r'missing unary operator "."', caplog.messages[0])
+    assert 1 == len(caplog.records) and "WARNING" == caplog.records[0].levelname
 
     # Unit replacements are stored
     configure(units=dict(replace={"foo": "bar"}))

--- a/genno/tests/test_util.py
+++ b/genno/tests/test_util.py
@@ -46,7 +46,12 @@ def test_filter_concat_args(caplog):
     assert len(result) == 1
 
 
-msg = "unit '{}' cannot be parsed; contains invalid character(s) '{}'"
+msg = (
+    # pint < 0.20
+    "unit '{}' cannot be parsed; contains invalid character(s) '{}'",
+    # pint >= 0.20
+    "Cannot define '{}' (UnitDefinition): is not a valid unit name",
+)
 
 
 @pytest.mark.parametrize(
@@ -60,9 +65,9 @@ msg = "unit '{}' cannot be parsed; contains invalid character(s) '{}'"
         # Dimensionless
         ([], "dimensionless"),
         # Invalid characters, alone or with prefix
-        (["_?"], (ValueError, re.escape(msg.format("_?", "?")))),
-        (["E$"], (ValueError, re.escape(msg.format("E$", "$")))),
-        (["kg-km"], (ValueError, re.escape(msg.format("kg-km", "-")))),
+        (["_?"], (ValueError, re.escape(msg[1].format("_?", "?")))),
+        (["E$"], (ValueError, re.escape(msg[1].format("E$", "$")))),
+        (["kg-km"], (ValueError, re.escape(msg[0].format("kg-km", "-")))),
     ),
     ids=lambda argvalue: repr(argvalue),
 )

--- a/genno/tests/test_util.py
+++ b/genno/tests/test_util.py
@@ -46,12 +46,7 @@ def test_filter_concat_args(caplog):
     assert len(result) == 1
 
 
-msg = (
-    # pint < 0.20
-    "unit '{}' cannot be parsed; contains invalid character(s) '{}'",
-    # pint >= 0.20
-    "Cannot define '{}' (UnitDefinition): is not a valid unit name",
-)
+msg = "unit '{}' cannot be parsed; contains invalid character(s) '{}'"
 
 
 @pytest.mark.parametrize(
@@ -65,13 +60,13 @@ msg = (
         # Dimensionless
         ([], "dimensionless"),
         # Invalid characters, alone or with prefix
-        (["_?"], (ValueError, re.escape(msg[1].format("_?", "?")))),
-        (["E$"], (ValueError, re.escape(msg[1].format("E$", "$")))),
-        (["kg-km"], (ValueError, re.escape(msg[0].format("kg-km", "-")))),
+        (["_?"], (ValueError, re.escape(msg.format("_?", "?")))),
+        (["E$"], (ValueError, re.escape(msg.format("E$", "$")))),
+        (["kg-km"], (ValueError, re.escape(msg.format("kg-km", "-")))),
     ),
     ids=lambda argvalue: repr(argvalue),
 )
-def test_parse_units(ureg, input, expected):
+def test_parse_units0(ureg, input, expected):
     if isinstance(expected, str):
         # Expected to work
         result = parse_units(input, ureg)
@@ -80,6 +75,14 @@ def test_parse_units(ureg, input, expected):
         # Expected to raise an exception
         with pytest.raises(expected[0], match=expected[1]):
             parse_units(pd.Series(input))
+
+
+def test_parse_units1(ureg, caplog):
+    """Multiple attempts to (re)define new units."""
+    parse_units("JPY")
+    parse_units("GBP/JPY")
+    with pytest.raises(ValueError):
+        parse_units("GBP/JPY/$?")
 
 
 @pytest.mark.parametrize(

--- a/genno/util.py
+++ b/genno/util.py
@@ -134,10 +134,10 @@ def parse_units(data: Iterable, registry=None) -> pint.Unit:
 
             # Try to parse again
             return registry.Unit(unit)
-        except (pint.UndefinedUnitError, pint.RedefinitionError):
-            # define() failed
+        except pint.PintError:
+            # registry.define() failed somehow
             raise invalid(unit)
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, pint.PintError):
         # Unit contains a character like '-' that throws off pint
         # NB this 'except' clause must be *after* UndefinedUnitError, since that is a
         #    subclass of AttributeError.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,8 @@ install_requires =
     PyYAML
     setuptools >= 41
     sparse >= 0.12
-    xarray >= 0.17
+    # 2022.6.0 is affected by pydata/xarray#6822
+    xarray >= 0.17, != 2022.6.0
 setup_requires =
     setuptools >= 41
     setuptools_scm
@@ -84,19 +85,13 @@ max-line-length = 88
 [mypy]
 [mypy-dask.*]
 ignore_missing_imports = True
-[mypy-numpy.*]
-ignore_missing_imports = True
 [mypy-pandas.*]
-ignore_missing_imports = True
-[mypy-pint.*]
 ignore_missing_imports = True
 [mypy-plotnine.*]
 ignore_missing_imports = True
 [mypy-pyam.*]
 ignore_missing_imports = True
 [mypy-scipy.*]
-ignore_missing_imports = True
-[mypy-setuptools.*]
 ignore_missing_imports = True
 [mypy-sparse.*]
 ignore_missing_imports = True


### PR DESCRIPTION
- Adjust for deprecation of `::set-output::` in GitHub Actions as described at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Remove workaround for/close #67.
- Remove pin of matplotlib, since upstream issue has been resolved by a new release.
- Adjust for pint 0.20.
- Allow `AttrSeries.cumprod()` with 1-dimensional quantities.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, CI changes only
- [x] Update doc/whatsnew.rst
