### PR TITLE
Test and fix `computations.select` with pandas 2.x

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
       type-hint-packages: >-
         importlib_resources
         nbclient
-        pint
+        "pint < 0.21"
         pytest
         types-PyYAML
         xarray

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,9 @@ What's new
 - Bug fix: :func:`.select` raised :class:`.KeyError` if the indexers contained values not appearing in the coords of the :class:`.Quantity` (:pull:`85`).
   This occurred with pandas 2.x, but not with earlier versions.
   The documentation now states explicitly that extraneous values are silently ignored.
+- All :mod:`.computations` are type hinted for the benefit of downstream code (:pull:`85`).
+- Implement :attr:`.AttrSeries.shape` (:pull:`85`).
+- Bug fix: :meth:`.Computer.add` now correctly handles positional-only keyword arguments to computations that specify these (:pull:`85`).
 
 v1.16.0 (2023-04-29)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,10 @@ What's new
 .. Next release
 .. ============
 
+- Bug fix: :func:`.select` raised :class:`.KeyError` if the indexers contained values not appearing in the coords of the :class:`.Quantity` (:pull:`85`).
+  This occurred with pandas 2.x, but not with earlier versions.
+  The documentation now states explicitly that extraneous values are silently ignored.
+
 v1.16.0 (2023-04-29)
 ====================
 

--- a/genno/compat/pyam/computations.py
+++ b/genno/compat/pyam/computations.py
@@ -1,4 +1,5 @@
 import logging
+from os import PathLike
 from pathlib import Path
 from typing import Callable, Collection, Optional, Union
 
@@ -91,7 +92,7 @@ def concat(*args, **kwargs):
         return genno.computations.concat(*args, **kwargs)
 
 
-def write_report(obj, path: Union[str, Path]) -> None:
+def write_report(obj, path: Union[str, PathLike]) -> None:
     """Write  obj` to the file at `path`.
 
     If `obj` is a :class:`pyam.IamDataFrame` and `path` ends with ".csv" or ".xlsx",

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -391,7 +391,7 @@ def drop_vars(
 
 def possible_scalar(value) -> Quantity:
     """Convert `value`, possibly a scalar, to :class:`Quantity`."""
-    if isinstance(value, float):
+    if isinstance(value, (float, np.number)):
         return Quantity(value)
     else:
         return value

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -6,6 +6,7 @@ import logging
 import operator
 import re
 from itertools import chain
+from os import PathLike
 from pathlib import Path
 from typing import Any, Collection, Hashable, Iterable, Mapping, Optional, Union, cast
 
@@ -837,7 +838,7 @@ def sum(quantity, weights=None, dimensions=None):
     return result
 
 
-def write_report(quantity, path):
+def write_report(quantity: Quantity, path: Union[str, PathLike]) -> None:
     """Write a quantity to a file.
 
     Parameters
@@ -852,4 +853,4 @@ def write_report(quantity, path):
     elif path.suffix == ".xlsx":
         quantity.to_dataframe().to_excel(path, merge_cells=False)
     else:
-        path.write_text(quantity)
+        path.write_text(quantity)  # type: ignore

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -770,7 +770,13 @@ def round(qty: Quantity, *args, **kwargs) -> Quantity:
     return qty.round(*args, **kwargs)
 
 
-def select(qty, indexers, inverse=False):
+def select(
+    qty: Quantity,
+    indexers: Mapping[Hashable, Iterable[Hashable]],
+    *,
+    inverse: bool = False,
+    drop: bool = False,
+) -> Quantity:
     """Select from `qty` based on `indexers`.
 
     Parameters
@@ -793,7 +799,7 @@ def select(qty, indexers, inverse=False):
         for dim, labels in indexers.items()
     }
 
-    return qty.sel(new_indexers)
+    return qty.sel(new_indexers, drop=drop)
 
 
 def sum(quantity, weights=None, dimensions=None):

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -519,7 +519,7 @@ class AttrSeries(pd.Series, Quantity):
                     {dim: other_index.levels[i] for i, dim in missing}
                 )
 
-            if len(self) == len(self.index.names) == 1:
+            if len(self) == len(self.index.names) == 1 and len(result.dims) > 0:
                 # concat() of scalars (= length-1 pd.Series) results in an innermost
                 # index level filled with int(0); discard this
                 result = result.droplevel(-1)

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -164,6 +164,7 @@ class AttrSeries(pd.Series, Quantity):
 
     @property
     def shape(self) -> Tuple[int, ...]:
+        """Like :attr:`xarray.DataArray.shape`."""
         idx = _multiindex_of(self).remove_unused_levels()
         return tuple(len(idx.levels[i]) for i in map(idx.names.index, self.dims))
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -295,7 +295,7 @@ class AttrSeries(pd.Series, Quantity):
             assert 0 == len(names)
             return super().rename(new_name_or_name_dict)
 
-    def sel(self, indexers=None, drop=False, **indexers_kwargs):
+    def sel(self, indexers=None, drop: bool = False, **indexers_kwargs):
         """Like :meth:`xarray.DataArray.sel`."""
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -162,6 +162,11 @@ class AttrSeries(pd.Series, Quantity):
         """Like :attr:`xarray.DataArray.dims`."""
         return tuple(filter(None, self.index.names))
 
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        idx = _multiindex_of(self).remove_unused_levels()
+        return tuple(len(idx.levels[i]) for i in map(idx.names.index, self.dims))
+
     def drop(self, label):
         """Like :meth:`xarray.DataArray.drop`."""
         return self.droplevel(label)

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -171,7 +171,10 @@ class AttrSeries(pd.Series, Quantity):
 
         result = self
         for name, values in reversed(list(dim.items())):
-            result = pd.concat([result] * len(values), keys=values, names=[name])
+            N = len(values)
+            if N == 0:  # Dimension without labels
+                N, values = 1, [None]
+            result = pd.concat([result] * N, keys=values, names=[name])
 
         return result
 

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -1,4 +1,5 @@
 from functools import update_wrapper
+from numbers import Number
 from typing import (
     Any,
     Dict,
@@ -322,7 +323,7 @@ def maybe_densify(func):
 
 def possible_scalar(value) -> Quantity:
     """Convert `value`, possibly a scalar, to :class:`Quantity`."""
-    return Quantity(value) if isinstance(value, (float, np.number)) else value
+    return Quantity(value) if isinstance(value, Number) else value
 
 
 def unwrap_scalar(qty: Quantity) -> Any:

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -1,5 +1,15 @@
 from functools import update_wrapper
-from typing import Any, Dict, Hashable, Iterable, Mapping, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import pandas as pd
@@ -84,6 +94,9 @@ class Quantity:
     def __mul__(self, other) -> "Quantity":  # type: ignore [empty-body]
         ...  # pragma: no cover
 
+    def __pow__(self, other) -> "Quantity":  # type: ignore [empty-body]
+        ...  # pragma: no cover
+
     def __radd__(self, other):
         ...  # pragma: no cover
 
@@ -143,6 +156,14 @@ class Quantity:
     ):  # NB "Quantity" here offends mypy
         ...  # pragma: no cover
 
+    def groupby(
+        self,
+        group,
+        squeeze: bool = True,
+        restore_coord_dims: bool = False,
+    ):
+        ...
+
     def interp(
         self,
         coords: Optional[Mapping[Any, Any]] = None,
@@ -195,6 +216,13 @@ class Quantity:
 
     def round(self, *args, **kwargs):
         ...  # pragma: no cover
+
+    def to_dataframe(
+        self,
+        name: Optional[Hashable] = None,
+        dim_order: Optional[Sequence[Hashable]] = None,
+    ) -> pd.DataFrame:
+        ...
 
     def to_numpy(self) -> np.ndarray:  # type: ignore [empty-body]
         ...  # pragma: no cover

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -318,3 +318,13 @@ def maybe_densify(func):
     update_wrapper(wrapped, func)
 
     return wrapped
+
+
+def possible_scalar(value) -> Quantity:
+    """Convert `value`, possibly a scalar, to :class:`Quantity`."""
+    return Quantity(value) if isinstance(value, (float, np.number)) else value
+
+
+def unwrap_scalar(qty: Quantity) -> Any:
+    """Unwrap `qty` to a scalar, if it is one."""
+    return qty if len(qty.dims) else qty.item()

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -162,7 +162,7 @@ class Quantity:
         squeeze: bool = True,
         restore_coord_dims: bool = False,
     ):
-        ...
+        ...  # pragma: no cover
 
     def interp(
         self,
@@ -222,7 +222,7 @@ class Quantity:
         name: Optional[Hashable] = None,
         dim_order: Optional[Sequence[Hashable]] = None,
     ) -> pd.DataFrame:
-        ...
+        ...  # pragma: no cover
 
     def to_numpy(self) -> np.ndarray:  # type: ignore [empty-body]
         ...  # pragma: no cover

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -48,6 +48,14 @@ def test_sel(bar):
     assert result.iloc[0] == 1
 
 
+def test_sel_not_implemented(bar):
+    with pytest.raises(NotImplementedError):
+        bar.sel(a="a2", method="bfill")
+
+    with pytest.raises(NotImplementedError):
+        bar.sel(a="a2", tolerance=0.01)
+
+
 def test_squeeze(foo):
     assert foo.sel(a="a1").squeeze().dims == ("b",)
     assert foo.sel(a="a2", b="b1").squeeze().values == 2

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -21,6 +21,33 @@ class TestAttrSeries:
         """A 1-dimensional quantity."""
         yield AttrSeries([0, 1], index=pd.Index(["a1", "a2"], name="a"))
 
+    def test_align_levels(self, foo, bar):
+        # Scalar vs scalar
+        q = AttrSeries(0.1)
+        other = AttrSeries(2.2)
+        result = q.align_levels(other)
+        assert tuple() == result.dims
+
+        # Scalar to 1D: broadcasts to 1D
+        result = q.align_levels(bar)
+        assert ("a",) == result.dims
+        assert 1 == len(result.unique())
+
+        # Scalar to 2D:
+        result = q.align_levels(foo)
+        assert ("a", "b") == result.dims
+        assert 1 == len(result.unique())
+
+        # 1D to scalar
+        result = bar.align_levels(q)
+        assert ("a",) == result.dims
+
+        # 2D vs. 2D; same dimensions, different order
+        idx = pd.MultiIndex.from_product([["b1", "b2"], ["a1", "a2"]], names=["b", "a"])
+        q = AttrSeries([3, 2, 1, 0], index=idx)
+        assert ("b", "a") == q.dims
+        assert ("a", "b") == q.align_levels(foo).dims
+
     def test_cumprod(self, bar):
         """AttrSeries.cumprod works with 1-dimensional quantities."""
         result0 = (1.1 + bar).cumprod("a")

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -8,95 +8,101 @@ from genno.core.attrseries import AttrSeries
 from genno.testing import add_large_data
 
 
-@pytest.fixture
-def foo():
-    idx = pd.MultiIndex.from_product([["a1", "a2"], ["b1", "b2"]], names=["a", "b"])
-    yield AttrSeries([0, 1, 2, 3], index=idx)
+class TestAttrSeries:
+    @pytest.fixture
+    @staticmethod
+    def foo():
+        idx = pd.MultiIndex.from_product([["a1", "a2"], ["b1", "b2"]], names=["a", "b"])
+        yield AttrSeries([0, 1, 2, 3], index=idx)
 
+    @pytest.fixture
+    @staticmethod
+    def bar():
+        """A 1-dimensional quantity."""
+        yield AttrSeries([0, 1], index=pd.Index(["a1", "a2"], name="a"))
 
-@pytest.fixture
-def bar():
-    """A 1-dimensional quantity."""
-    yield AttrSeries([0, 1], index=pd.Index(["a1", "a2"], name="a"))
+    def test_cumprod(self, bar):
+        """AttrSeries.cumprod works with 1-dimensional quantities."""
+        result0 = (1.1 + bar).cumprod("a")
+        assert ("a",) == result0.dims
 
+        # Same result with dim=None
+        result1 = (1.1 + bar).cumprod()
+        pdt.assert_series_equal(result0, result1)
 
-def test_cumprod(bar):
-    """AttrSeries.cumprod works with 1-dimensional quantities."""
-    result0 = (1.1 + bar).cumprod("a")
-    assert ("a",) == result0.dims
+    def test_interp(self, foo):
+        with pytest.raises(NotImplementedError):
+            foo.interp(coords=dict(a=["a1", "a1.5", "a2"], b=["b1", "b1.5", "b2"]))
 
-    # Same result with dim=None
-    result1 = (1.1 + bar).cumprod()
-    pdt.assert_series_equal(result0, result1)
+    def test_rename(self, foo):
+        assert foo.rename({"a": "c", "b": "d"}).dims == ("c", "d")
 
+    def test_sel(self, bar):
+        # Selecting 1 element from 1-D parameter still returns AttrSeries
+        result = bar.sel(a="a2")
+        assert isinstance(result, AttrSeries)
+        assert result.size == 1
+        assert result.dims == ("a",)
+        assert result.iloc[0] == 1
 
-def test_interp(foo):
-    with pytest.raises(NotImplementedError):
-        foo.interp(coords=dict(a=["a1", "a1.5", "a2"], b=["b1", "b1.5", "b2"]))
+    def test_sel_not_implemented(self, bar):
+        with pytest.raises(NotImplementedError):
+            bar.sel(a="a2", method="bfill")
 
+        with pytest.raises(NotImplementedError):
+            bar.sel(a="a2", tolerance=0.01)
 
-def test_rename(foo):
-    assert foo.rename({"a": "c", "b": "d"}).dims == ("c", "d")
+    def test_squeeze(self, foo):
+        assert foo.sel(a="a1").squeeze().dims == ("b",)
+        assert foo.sel(a="a2", b="b1").squeeze().values == 2
 
+        with pytest.raises(
+            ValueError,
+            match="dimension to squeeze out which has length greater than one",
+        ):
+            foo.squeeze(dim="b")
 
-def test_sel(bar):
-    # Selecting 1 element from 1-D parameter still returns AttrSeries
-    result = bar.sel(a="a2")
-    assert isinstance(result, AttrSeries)
-    assert result.size == 1
-    assert result.dims == ("a",)
-    assert result.iloc[0] == 1
+        with pytest.raises(KeyError, match="c"):
+            foo.squeeze(dim="c")
 
+    def test_sum(self, foo, bar):
+        # AttrSeries can be summed across all dimensions
+        result = foo.sum(dim=["a", "b"])
+        assert isinstance(result, AttrSeries)  # returns an AttrSeries
+        assert result.size == 1  # with one element
+        assert result.item() == 6  # that has the correct value
 
-def test_sel_not_implemented(bar):
-    with pytest.raises(NotImplementedError):
-        bar.sel(a="a2", method="bfill")
+        # Sum with wrong dim raises ValueError
+        with pytest.raises(ValueError):
+            bar.sum("b")
 
-    with pytest.raises(NotImplementedError):
-        bar.sel(a="a2", tolerance=0.01)
+        # Index with duplicate entries
+        _baz = pd.DataFrame(
+            [
+                ["a1", "b1", "c1", 1.0],
+                ["a1", "b1", "c1", 2.0],
+                ["a2", "b2", "c3", 3.0],
+                ["a2", "b2", "c4", 4.0],
+                ["a3", "b3", "c5", 5.0],
+            ],
+            columns=["a", "b", "c", "value"],
+        )
+        # Fails with v1.13.0 AttrSeries.sum() using unstack()
+        AttrSeries(_baz.set_index(["a", "b", "c"])["value"]).sum(dim="c")
 
+        with pytest.raises(NotImplementedError):
+            bar.sum("a", skipna=False)
 
-def test_squeeze(foo):
-    assert foo.sel(a="a1").squeeze().dims == ("b",)
-    assert foo.sel(a="a2", b="b1").squeeze().values == 2
+    def test_others(self, foo, bar):
+        # Exercise other compatibility functions
+        assert type(foo.to_frame()) is pd.DataFrame
+        assert foo.drop("a").dims == ("b",)
+        assert bar.dims == ("a",)
 
-    with pytest.raises(
-        ValueError,
-        match="dimension to squeeze out which has length greater than one",
-    ):
-        foo.squeeze(dim="b")
-
-    with pytest.raises(KeyError, match="c"):
-        foo.squeeze(dim="c")
-
-
-def test_sum(foo, bar):
-    # AttrSeries can be summed across all dimensions
-    result = foo.sum(dim=["a", "b"])
-    assert isinstance(result, AttrSeries)  # returns an AttrSeries
-    assert result.size == 1  # with one element
-    assert result.item() == 6  # that has the correct value
-
-    # Sum with wrong dim raises ValueError
-    with pytest.raises(ValueError):
-        bar.sum("b")
-
-    # Index with duplicate entries
-    _baz = pd.DataFrame(
-        [
-            ["a1", "b1", "c1", 1.0],
-            ["a1", "b1", "c1", 2.0],
-            ["a2", "b2", "c3", 3.0],
-            ["a2", "b2", "c4", 4.0],
-            ["a3", "b3", "c5", 5.0],
-        ],
-        columns=["a", "b", "c", "value"],
-    )
-    # Fails with v1.13.0 AttrSeries.sum() using unstack()
-    AttrSeries(_baz.set_index(["a", "b", "c"])["value"]).sum(dim="c")
-
-    with pytest.raises(NotImplementedError):
-        bar.sum("a", skipna=False)
+        with pytest.raises(NotImplementedError):
+            bar.item("a2")
+        with pytest.raises(ValueError):
+            bar.item()
 
 
 @pytest.mark.skip
@@ -111,15 +117,3 @@ def test_sum_large(N_data=1e7):  # pragma: no cover
     result = qty.sum(dim=["j", "k"])
     # print(result)  # DEBUG
     del result
-
-
-def test_others(foo, bar):
-    # Exercise other compatibility functions
-    assert type(foo.to_frame()) is pd.DataFrame
-    assert foo.drop("a").dims == ("b",)
-    assert bar.dims == ("a",)
-
-    with pytest.raises(NotImplementedError):
-        bar.item("a2")
-    with pytest.raises(ValueError):
-        bar.item()

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -10,14 +10,12 @@ from genno.testing import add_large_data
 
 class TestAttrSeries:
     @pytest.fixture
-    @staticmethod
-    def foo():
+    def foo(self):
         idx = pd.MultiIndex.from_product([["a1", "a2"], ["b1", "b2"]], names=["a", "b"])
         yield AttrSeries([0, 1, 2, 3], index=idx)
 
     @pytest.fixture
-    @staticmethod
-    def bar():
+    def bar(self):
         """A 1-dimensional quantity."""
         yield AttrSeries([0, 1], index=pd.Index(["a1", "a2"], name="a"))
 

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -18,7 +18,6 @@ from genno import (
     computations,
 )
 from genno.compat.pint import ApplicationRegistry
-from genno.core.attrseries import AttrSeries
 from genno.testing import (
     add_dantzig,
     add_test_data,
@@ -494,8 +493,8 @@ def test_dantzig(ureg):
 
     # Summation across all dimensions results a 1-element Quantity
     d = c.get("d:")
-    assert d.shape == ((1,) if Quantity._get_class() is AttrSeries else tuple())
-    assert d.size == 1
+    assert tuple() == d.shape
+    assert 1 == d.size
     assert np.isclose(d.values, 11.7)
 
     # Weighted sum

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -194,6 +194,17 @@ class TestQuantity:
         q0 = a.expand_dims({"phase": ["liquid"]})
         assert ("phase", "p") == q0.dims
 
+        # New dimension(s) without labels
+        q1 = a.expand_dims({"phase": []})
+        assert ("phase", "p") == q1.dims
+        assert 2 == q1.size
+        assert (1, 2) == q1.shape
+
+        # NB this behaviour differs slightly from xr.DataArray.expand_dims()
+        # da = xr.DataArray([0.8, 0.2], coords=[["oil", "water"]], dims=["p"])
+        # assert (0, 2) == da.expand_dims({"phase": []}).shape  # Different result
+        # assert (1, 2) == da.expand_dims(["phase"]).shape  # Same result
+
         # Multiple labels
         q1 = a.expand_dims({"phase": ["liquid", "solid"]})
         assert ("phase", "p") == q1.dims

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -3,6 +3,7 @@ import logging
 import operator
 import re
 
+import numpy as np
 import pandas as pd
 import pint
 import pytest
@@ -12,12 +13,13 @@ from pytest import param
 
 from genno import Computer, Quantity, computations
 from genno.core.attrseries import AttrSeries
-from genno.core.quantity import assert_quantity
+from genno.core.quantity import assert_quantity, possible_scalar, unwrap_scalar
 from genno.core.sparsedataarray import SparseDataArray
 from genno.testing import add_large_data, assert_qty_allclose, assert_qty_equal
 
+pytsetmark = pytest.mark.usefixtures("parametrize_quantity_class")
 
-@pytest.mark.usefixtures("parametrize_quantity_class")
+
 class TestQuantity:
     """Tests of Quantity."""
 
@@ -319,3 +321,21 @@ class TestQuantity:
 
         assert (2,) == result.shape
         assert a.dtype == result.dtype
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        2,
+        np.int64(2),
+        1.1,
+        np.float64(1.1),
+        pytest.param([0.1, 2.3], marks=pytest.mark.xfail(raises=AssertionError)),
+    ],
+)
+def test_possible_scalar(value):
+    tmp = possible_scalar(value)
+    assert isinstance(tmp, Quantity), type(tmp)
+    assert tuple() == tmp.dims
+
+    assert value == unwrap_scalar(tmp)

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -617,13 +617,15 @@ def test_select(data):
     # Unpack
     *_, t_foo, t_bar, x = data
 
+    N_y = 6
+
     x = Quantity(x)
-    assert x.size == 6 * 6
+    assert x.size == 6 * N_y
 
     # Selection with inverse=False
     indexers = {"t": t_foo[0:1] + t_bar[0:1]}
     result_0 = computations.select(x, indexers=indexers)
-    assert result_0.size == 2 * 6
+    assert result_0.size == 2 * N_y
 
     # Single indexer along one dimension results in 1D data
     indexers["y"] = [2010]
@@ -632,4 +634,8 @@ def test_select(data):
 
     # Selection with inverse=True
     result_2 = computations.select(x, indexers=indexers, inverse=True)
-    assert result_2.size == 4 * 5
+    assert result_2.size == 4 * (N_y - 1)
+
+    # Select with labels that do not appear in the data
+    result_3 = computations.select(x, indexers={"t": t_foo + ["MISSING"]})
+    assert result_3.size == len(t_foo) * N_y

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -639,3 +639,18 @@ def test_select(data):
     # Select with labels that do not appear in the data
     result_3 = computations.select(x, indexers={"t": t_foo + ["MISSING"]})
     assert result_3.size == len(t_foo) * N_y
+
+    # Select with xarray indexers
+    indexers = {
+        "t": xr.DataArray(
+            t_foo, dims="new_dim", coords={"new_dim": ["d1", "d2", "d3"]}
+        ),
+        "y": xr.DataArray(
+            [2000, 2010, 2020], dims="new_dim", coords={"new_dim": ["d1", "d2", "d3"]}
+        ),
+    }
+    result_4 = computations.select(x, indexers)
+    assert ("new_dim",) == result_4.dims
+
+    with pytest.raises(NotImplementedError):
+        computations.select(x, indexers, inverse=True)

--- a/genno/tests/test_util.py
+++ b/genno/tests/test_util.py
@@ -12,6 +12,7 @@ from genno.util import (
     collect_units,
     filter_concat_args,
     parse_units,
+    partial_split,
     unquote,
 )
 
@@ -86,6 +87,24 @@ def test_parse_units1(ureg, caplog):
     parse_units("GBP/JPY")
     with pytest.raises(pint.DefinitionSyntaxError):
         parse_units("GBP/JPY/$?")
+
+
+def test_partial_split():
+    # Function with ordinary arguments
+    def func1(arg1, arg2, foo=-1, bar=-1):
+        pass  # pragma: no cover
+
+    # Function with keyword-only arguments
+    def func2(arg1, arg2, *, foo, bar):
+        pass  # pragma: no cover
+
+    kwargs = dict(arg1=0, foo=1, bar=2, baz=3)
+
+    _, extra = partial_split(func1, kwargs)
+    assert {"baz"} == set(extra.keys())
+
+    _, extra = partial_split(func2, kwargs)
+    assert {"baz"} == set(extra.keys())
 
 
 @pytest.mark.parametrize(

--- a/genno/util.py
+++ b/genno/util.py
@@ -1,7 +1,7 @@
 import logging
 from functools import partial
 from inspect import Parameter, signature
-from typing import Iterable, Mapping, Type, Union
+from typing import Callable, Iterable, Mapping, Tuple, Type, Union
 
 import pandas as pd
 import pint
@@ -146,19 +146,21 @@ def parse_units(data: Iterable, registry=None) -> pint.Unit:
         raise invalid(unit, e)
 
 
-def partial_split(func, kwargs):
+def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, Mapping]:
     """Forgiving version of :func:`functools.partial`.
 
-    Returns a partial object and leftover kwargs not applicable to `func`.
+    Returns a :class:`partial` object and leftover kwargs not applicable to `func`.
     """
-    # Names of parameters to
+    # Names of parameters to `func`
     par_names = signature(func).parameters
+
     func_args, extra = {}, {}
     for name, value in kwargs.items():
         if name in par_names and par_names[name].kind in (
             Parameter.POSITIONAL_OR_KEYWORD,
             Parameter.KEYWORD_ONLY,
         ):
+            # A keyword argument of `func`
             func_args[name] = value
         else:
             extra[name] = value

--- a/genno/util.py
+++ b/genno/util.py
@@ -155,9 +155,9 @@ def partial_split(func, kwargs):
     par_names = signature(func).parameters
     func_args, extra = {}, {}
     for name, value in kwargs.items():
-        if (
-            name in par_names
-            and par_names[name].kind == Parameter.POSITIONAL_OR_KEYWORD
+        if name in par_names and par_names[name].kind in (
+            Parameter.POSITIONAL_OR_KEYWORD,
+            Parameter.KEYWORD_ONLY,
         ):
             func_args[name] = value
         else:


### PR DESCRIPTION
iiasa/message_data#442 revealed that select() raises KeyError with pandas 2.0.1 if the indexers contain labels not appearing in the underlying data.

### PR checklist
- [x] Expand tests
  - [x] partial_split()
  - [x] possible_scalar()
  - [x] AttrSeries.align_levels()
  - [x] AttrSeries.expand_dims()
- [x] Checks all ✅
- ~Update documentation~ N/A
- [x] Update doc/whatsnew.rst
