### PR TITLE
Fix AttrSeries alignment for binary operations

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -184,8 +184,6 @@ Top-level classes and functions
           keys = rep.convert_pyam(ACT, 'ya', collapse=m_t, drop=['t', 'm'])
 
 
-
-
 .. autoclass:: genno.Key
    :members:
 
@@ -348,6 +346,10 @@ Internal format for quantities
 
 .. automodule:: genno.core.sparsedataarray
    :members: SparseDataArray, SparseAccessor
+
+.. currentmodule:: genno.compat.xarray
+
+.. autoclass:: DataArrayLike
 
 
 Utilities

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,14 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bug fix: genno v1.16.1 (:pull:`85`) introduced :class:`ValueError` for some usages of :func:`.computations.sum` (:pull:`88`).
+- Provide typed signatures for :meth:`Quantity.bfill`, :meth:`~Quantity.cumprod`, :meth:`~Quantity.ffill` for the benefit of downstream applications (:pull:`88`).
+- Ensure and test that :attr:`.Quantity.name` and :attr:`~.Quantity.units` pass through all :mod:`.computations`, in particular :func:`~.computations.aggregate`, :func:`~.computations.convert_units`, and :func:`~.computations.sum` (:pull:`88`).
+- Simplify arithmetic operations (:func:`~.computations.div`, :func:`~.computations.mul`, :func:`~.computations.pow`) so they are agnostic as to the :class:`.Quantity` class in use (:pull:`88`).
+- Ensure :attr:`.AttrSeries.index` is always :class:`pandas.MultiIndex` (:pull:`88`).
 
 v1.16.1 (2023-05-13)
 ====================

--- a/genno/compat/xarray.py
+++ b/genno/compat/xarray.py
@@ -1,3 +1,4 @@
+"""Compatibility with :mod:`xarray`."""
 from typing import (
     Any,
     Dict,
@@ -23,6 +24,14 @@ T = TypeVar("T", covariant=True)
 
 
 class DataArrayLike(Generic[T]):
+    """Class with :class:`.xarray.DataArray` -like API.
+
+    This class is used to set signatures and types for methods and attributes on the
+    generic :class:`.Quantity` class. :class:`.SparseDataArray` inherits from both this
+    class and :class:`~xarray.DataArray`, and thus DataArray supplies implementations of
+    these methods. In :class:`.AttrSeries`, the methods are implemented directly.
+    """
+
     # To silence a warning in xarray
     __slots__: Tuple[str, ...] = tuple()
 
@@ -158,6 +167,9 @@ class DataArrayLike(Generic[T]):
     ):
         ...  # pragma: no cover
 
+    def round(self, *args, **kwargs):
+        ...  # pragma: no cover
+
     def sel(
         self,
         indexers: Optional[Mapping[Any, Any]] = None,
@@ -186,9 +198,6 @@ class DataArrayLike(Generic[T]):
         keep_attrs: Optional[bool] = None,
         **kwargs: Any,
     ):  # TODO set the return type
-        ...  # pragma: no cover
-
-    def round(self, *args, **kwargs):
         ...  # pragma: no cover
 
     def to_dataframe(

--- a/genno/compat/xarray.py
+++ b/genno/compat/xarray.py
@@ -1,0 +1,208 @@
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Hashable,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+import numpy as np
+import pandas as pd
+import xarray
+from xarray.core.types import InterpOptions
+
+from genno.core.types import Dims
+
+T = TypeVar("T", covariant=True)
+
+
+class DataArrayLike(Generic[T]):
+    # To silence a warning in xarray
+    __slots__: Tuple[str, ...] = tuple()
+
+    # Type hints for mypy in downstream applications
+    # @abstractmethod  # NB this suppresses a mypy "empty-body" error
+    def __len__(self) -> int:
+        return NotImplemented  # pragma: no cover
+
+    # @abstractmethod  # NB this suppresses a mypy "empty-body" error
+    def __mul__(self, other):  # TODO set the return type
+        ...  # pragma: no cover
+
+    # @abstractmethod
+    def __pow__(self, other):  # TODO set the return type
+        ...  # pragma: no cover
+
+    def __radd__(self, other):
+        ...  # pragma: no cover
+
+    def __rmul__(self, other):
+        ...  # pragma: no cover
+
+    def __rsub__(self, other):
+        ...  # pragma: no cover
+
+    def __rtruediv__(self, other):
+        ...  # pragma: no cover
+
+    # @abstractmethod  # NB this suppresses a mypy "empty-body" error
+    def __truediv__(self, other):  # TODO set the return type
+        ...  # pragma: no cover
+
+    @property
+    def attrs(self) -> Dict[Any, Any]:
+        return NotImplemented  # pragma: no cover
+
+    @property
+    # @abstractmethod
+    def coords(
+        self,
+    ) -> xarray.core.coordinates.DataArrayCoordinates:
+        return NotImplemented  # pragma: no cover
+
+    @property
+    # @abstractmethod
+    def dims(self) -> Tuple[Hashable, ...]:
+        return NotImplemented  # pragma: no cover
+
+    def assign_coords(
+        self,
+        coords: Optional[Mapping[Any, Any]] = None,
+        **coords_kwargs: Any,
+    ):
+        ...  # pragma: no cover
+
+    # @abstractmethod
+    def bfill(
+        self,
+        dim: Hashable,
+        limit: Optional[int] = None,
+    ):  # TODO set the return type
+        ...  # pragma: no cover
+
+    # @abstractmethod
+    def copy(
+        self,
+        deep: bool = True,
+        data: Any = None,
+    ):  # TODO set the return type
+        ...  # pragma: no cover
+
+    # @abstractmethod
+    def cumprod(
+        self,
+        dim: Dims = None,
+        *,
+        skipna: Optional[bool] = None,
+        keep_attrs: Optional[bool] = None,
+        **kwargs: Any,
+    ):  # TODO set the return type
+        ...  # pragma: no cover
+
+    def drop_vars(
+        self,
+        names: Union[Hashable, Iterable[Hashable]],
+        *,
+        errors="raise",
+    ):
+        ...  # pragma: no cover
+
+    def expand_dims(
+        self,
+        dim=None,
+        axis=None,
+        **dim_kwargs: Any,
+    ):  # TODO set the return type
+        ...  # pragma: no cover
+
+    # @abstractmethod
+    def ffill(
+        self,
+        dim: Hashable,
+        limit: Optional[int] = None,
+    ):  # TODO set the return type
+        return NotImplemented  # pragma: no cover
+
+    def groupby(
+        self,
+        group,
+        squeeze: bool = True,
+        restore_coord_dims: bool = False,
+    ):
+        ...  # pragma: no cover
+
+    def interp(
+        self,
+        coords: Optional[Mapping[Any, Any]] = None,
+        method: InterpOptions = "linear",
+        assume_sorted: bool = False,
+        kwargs: Optional[Mapping[str, Any]] = None,
+        **coords_kwargs: Any,
+    ):
+        ...  # pragma: no cover
+
+    def item(self, *args):
+        ...  # pragma: no cover
+
+    # @abstractmethod
+    def rename(
+        self,
+        new_name_or_name_dict: Union[Hashable, Mapping[Any, Hashable]] = None,
+        **names: Hashable,
+    ):
+        ...  # pragma: no cover
+
+    def sel(
+        self,
+        indexers: Optional[Mapping[Any, Any]] = None,
+        method: Optional[str] = None,
+        tolerance=None,
+        drop: bool = False,
+        **indexers_kwargs: Any,
+    ):  # TODO set the return type
+        return NotImplemented  # pragma: no cover
+
+    def shift(
+        self,
+        shifts: Optional[Mapping[Hashable, int]] = None,
+        fill_value: Any = None,
+        **shifts_kwargs: int,
+    ):  # TODO set the return type
+        ...  # pragma: no cover
+
+    def sum(
+        self,
+        dim: Dims = None,
+        # Signature from xarray.DataArray
+        *,
+        skipna: Optional[bool] = None,
+        min_count: Optional[int] = None,
+        keep_attrs: Optional[bool] = None,
+        **kwargs: Any,
+    ):  # TODO set the return type
+        ...  # pragma: no cover
+
+    def round(self, *args, **kwargs):
+        ...  # pragma: no cover
+
+    def to_dataframe(
+        self,
+        name: Optional[Hashable] = None,
+        dim_order: Optional[Sequence[Hashable]] = None,
+    ) -> pd.DataFrame:
+        ...  # pragma: no cover
+
+    def to_numpy(self) -> np.ndarray:
+        return NotImplemented  # pragma: no cover
+
+    def to_series(self) -> pd.Series:
+        """Like :meth:`xarray.DataArray.to_series`."""
+        # Provided only for type-checking in other packages. AttrSeries implements;
+        # SparseDataArray uses the xr.DataArray method.
+        return NotImplemented  # pragma: no cover

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -5,6 +5,7 @@
 import logging
 import operator
 import re
+from functools import reduce
 from itertools import chain
 from os import PathLike
 from pathlib import Path
@@ -656,20 +657,9 @@ def _load_file_csv(
 
 def mul(*quantities: Quantity) -> Quantity:
     """Compute the product of any number of *quantities*."""
-    # Iterator over (quantity, unit) tuples
-    items = zip(quantities, collect_units(*quantities))
 
-    # Initialize result values with first entry
-    result, u_result = next(items)
-
-    # Iterate over remaining entries
-    for q, u in items:
-        if isinstance(q, AttrSeries):
-            # Work around pandas-dev/pandas#25760; see attrseries.py
-            result = (result * q.align_levels(result)).dropna()
-        else:
-            result = result * q
-        u_result *= u
+    result = reduce(operator.mul, quantities)
+    u_result = reduce(operator.mul, collect_units(*quantities))
 
     result.units = u_result
 

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -424,21 +424,13 @@ def div(numerator: Union[Quantity, float], denominator: Quantity) -> Quantity:
     # Handle units
     u_num, u_denom = collect_units(numerator, denominator)
 
-    if isinstance(numerator, AttrSeries):
-        result = unwrap_scalar(numerator) / cast(AttrSeries, denominator).align_levels(
-            numerator
-        )
-    else:
-        result = numerator / denominator
+    result = numerator / denominator
 
     # This shouldn't be necessary; would instead prefer:
     # result.units = u_num / u_denom
     # … but is necessary to avoid an issue when the operands are different Unit classes
     ureg = pint.get_application_registry()
-    result.attrs["_unit"] = ureg.Unit(u_num) / ureg.Unit(u_denom)
-
-    if isinstance(result, AttrSeries):
-        result.dropna(inplace=True)
+    result.units = ureg.Unit(u_num) / ureg.Unit(u_denom)
 
     return result
 

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -688,10 +688,7 @@ def pow(a: Quantity, b: Union[Quantity, int]) -> Quantity:
     if not u_b.dimensionless:
         raise ValueError(f"Cannot raise to a power with units ({u_b:~})")
 
-    if isinstance(a, AttrSeries):
-        result = a ** cast(AttrSeries, b).align_levels(a)
-    else:
-        result = a**b
+    result = a**b
 
     result.units = (
         a.units**unit_exponent

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -359,7 +359,7 @@ def concat(*objs: Quantity, **kwargs) -> Quantity:
         # Ensure objects have aligned dimensions
         _objs = [objs[0]]
         _objs.extend(
-            map(lambda o: cast(AttrSeries, o).align_levels(_objs[0]), objs[1:])
+            map(lambda o: cast(AttrSeries, o).align_levels(_objs[0])[1], objs[1:])
         )
 
         return pd.concat(_objs, **kwargs)
@@ -755,7 +755,7 @@ def relabel(
 
     if isinstance(qty, AttrSeries):
         # Prepare a new index
-        idx = _multiindex_of(qty)
+        idx = qty.index.copy()
         for dim, label_map in iter:
             # - Look up numerical index of the dimension in `idx`
             # - Retrieve the existing levels.
@@ -766,10 +766,7 @@ def relabel(
             )
 
         # Assign the new index to a copy of qty
-        result = cast(AttrSeries, qty.copy())
-        result.index = idx
-
-        return result
+        return qty.set_axis(idx)
     else:
         return cast(SparseDataArray, qty).assign_coords(
             {dim: map_labels(m, qty.coords[dim].data) for dim, m in iter}

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -26,13 +26,12 @@ import pint
 from xarray.core.types import InterpOptions
 from xarray.core.utils import either_dict_or_kwargs
 
-from genno.core.attrseries import AttrSeries, _multiindex_of
+from genno.core.attrseries import AttrSeries
 from genno.core.quantity import (
     Quantity,
     assert_quantity,
     maybe_densify,
     possible_scalar,
-    unwrap_scalar,
 )
 from genno.core.sparsedataarray import SparseDataArray
 from genno.util import UnitLike, collect_units, filter_concat_args

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -329,7 +329,7 @@ def combine(
         args.append(weight * temp)
 
     result = add(*args)
-    result.attrs["_unit"] = units
+    result.units = units
 
     return result
 
@@ -405,7 +405,7 @@ def convert_units(qty: Quantity, units: UnitLike) -> Quantity:
 def disaggregate_shares(quantity: Quantity, shares: Quantity) -> Quantity:
     """Disaggregate *quantity* by *shares*."""
     result = quantity * shares
-    result.attrs["_unit"] = collect_units(quantity)[0]
+    result.units = collect_units(quantity)[0]
     return result
 
 
@@ -431,7 +431,7 @@ def div(numerator: Union[Quantity, float], denominator: Quantity) -> Quantity:
         result = numerator / denominator
 
     # This shouldn't be necessary; would instead prefer:
-    # result.attrs["_unit"] = u_num / u_denom
+    # result.units = u_num / u_denom
     # … but is necessary to avoid an issue when the operands are different Unit classes
     ureg = pint.get_application_registry()
     result.attrs["_unit"] = ureg.Unit(u_num) / ureg.Unit(u_denom)
@@ -671,7 +671,7 @@ def mul(*quantities: Quantity) -> Quantity:
             result = result * q
         u_result *= u
 
-    result.attrs["_unit"] = u_result
+    result.units = u_result
 
     return result
 
@@ -711,8 +711,8 @@ def pow(a: Quantity, b: Union[Quantity, int]) -> Quantity:
     else:
         result = a**b
 
-    result.attrs["_unit"] = (
-        a.attrs["_unit"] ** unit_exponent
+    result.units = (
+        a.units**unit_exponent
         if unit_exponent
         else pint.get_application_registry().dimensionless
     )

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -90,6 +90,12 @@ class AttrSeries(pd.Series, Quantity):
         # Don't pass attrs to pd.Series constructor; it currently does not accept them
         pd.Series.__init__(self, data, *args, name=name, **kwargs)
 
+        # Ensure a MultiIndex
+        try:
+            self.index.levels
+        except AttributeError:
+            self.index = pd.MultiIndex.from_product([self.index])
+
         # Update the attrs after initialization
         self.attrs.update(attrs)
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -207,6 +207,8 @@ class AttrSeries(pd.Series, Quantity):
 
     def expand_dims(self, dim=None, axis=None, **dim_kwargs: Any) -> "AttrSeries":
         """Like :meth:`xarray.DataArray.expand_dims`."""
+        if isinstance(dim, list):
+            dim = dict.fromkeys(dim, [])
         dim = either_dict_or_kwargs(dim, dim_kwargs, "expand_dims")
         if axis is not None:
             raise NotImplementedError  # pragma: no cover

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -629,7 +629,10 @@ class AttrSeries(pd.Series, Quantity):
         else:
             # Group on dimensions other than `dim`
             return self.groupby(
-                list(filter(lambda d: d not in dim, self.index.names)),  # type: ignore
+                level=list(  # type: ignore
+                    filter(lambda d: d not in dim, self.index.names)
+                ),
+                group_keys=False,
                 observed=True,
             )
 

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -164,12 +164,7 @@ class AttrSeries(pd.Series, Quantity):
     @property
     def coords(self):
         """Like :attr:`xarray.DataArray.coords`. Read-only."""
-        levels = (
-            self.index.levels
-            if isinstance(self.index, pd.MultiIndex)
-            else [self.index.values]
-        )
-        return xr.Dataset(None, coords=dict(zip(self.index.names, levels))).coords
+        return xr.DataArray(coords=self.index.levels, dims=self.dims).coords
 
     def cumprod(self, dim=None, axis=None, skipna=None, **kwargs):
         """Like :meth:`xarray.DataArray.cumprod`."""

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -16,7 +16,7 @@ from typing import (
     cast,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from _typeshed import SupportsRichComparisonT
 
 import numpy as np

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -569,7 +569,7 @@ class AttrSeries(pd.Series, Quantity):
     def _groupby_apply(
         self,
         dim: Hashable,
-        levels: Iterable[SupportsRichComparisonT],
+        levels: Iterable["SupportsRichComparisonT"],
         func: Callable[["AttrSeries"], "AttrSeries"],
     ) -> "AttrSeries":
         """Group along `dim`, ensure levels `levels`, and apply `func`.

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -368,13 +368,9 @@ class AttrSeries(pd.Series, Quantity):
         if len(indexers) == 1:
             level, key = list(indexers.items())[0]
             if isinstance(key, str) and not drop:
-                if isinstance(self.index, pd.MultiIndex):
-                    # When using .loc[] to select 1 label on 1 level, pandas drops the
-                    # level. Use .xs() to avoid this behaviour unless drop=True
-                    return AttrSeries(self.xs(key, level=level, drop_level=False))
-                else:
-                    # No MultiIndex; use .loc with a slice to avoid returning scalar
-                    return self.loc[slice(key, key)]
+                # When using .loc[] to select 1 label on 1 level, pandas drops the
+                # level. Use .xs() to avoid this behaviour unless drop=True
+                return AttrSeries(self.xs(key, level=level, drop_level=False))
 
         if len(indexers) and all(
             isinstance(i, xr.DataArray) for i in indexers.values()

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -198,6 +198,15 @@ class AttrSeries(pd.Series, Quantity):
                 N, values = 1, [None]
             result = pd.concat([result] * N, keys=values, names=[name])
 
+        # Ensure `result` is multiindexed
+        try:
+            i = result.index.names.index(None)
+        except ValueError:
+            pass
+        else:
+            assert 2 == len(result.index.names)
+            result.index = pd.MultiIndex.from_product([result.index.droplevel(i)])
+
         return result
 
     def ffill(self, dim: Hashable, limit: Optional[int] = None):

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -1,51 +1,29 @@
 from functools import update_wrapper
 from numbers import Number
-from typing import (
-    Any,
-    Dict,
-    Hashable,
-    Iterable,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Any, Hashable, Optional
 
-import numpy as np
 import pandas as pd
 import pint
-import xarray
-from xarray.core.types import InterpOptions
 
-from .types import Dims
+from genno.compat.xarray import DataArrayLike
 
 #: Name of the class used to implement :class:`.Quantity`.
 CLASS = "AttrSeries"
 # CLASS = "SparseDataArray"
 
 
-class Quantity:
+class Quantity(DataArrayLike["Quantity"]):
     """A sparse data structure that behaves like :class:`xarray.DataArray`.
 
     Depending on the value of :data:`CLASS`, Quantity is either :class:`.AttrSeries` or
     :class:`SparseDataArray`.
     """
 
-    # To silence a warning in xarray
-    __slots__: Tuple[str, ...] = tuple()
-
     _name: Optional[Hashable]
 
     def __new__(cls, *args, **kwargs):
         # Use _get_class() to retrieve either AttrSeries or SparseDataArray
         return object.__new__(Quantity._get_class(cls))
-
-    def to_series(self) -> pd.Series:
-        """Like :meth:`xarray.DataArray.to_series`."""
-        # Provided only for type-checking in other packages. AttrSeries implements;
-        # SparseDataArray uses the xr.DataArray method.
-        return NotImplemented  # pragma: no cover
 
     @classmethod
     def from_series(cls, series, sparse=True):
@@ -87,170 +65,6 @@ class Quantity:
     @units.setter
     def units(self, value):
         self.attrs["_unit"] = pint.get_application_registry().Unit(value)
-
-    # Type hints for mypy in downstream applications
-    def __len__(self) -> int:  # type: ignore [empty-body]
-        ...  # pragma: no cover
-
-    def __mul__(self, other) -> "Quantity":  # type: ignore [empty-body]
-        ...  # pragma: no cover
-
-    def __pow__(self, other) -> "Quantity":  # type: ignore [empty-body]
-        ...  # pragma: no cover
-
-    def __radd__(self, other):
-        ...  # pragma: no cover
-
-    def __rmul__(self, other):
-        ...  # pragma: no cover
-
-    def __rsub__(self, other):
-        ...  # pragma: no cover
-
-    def __rtruediv__(self, other):
-        ...  # pragma: no cover
-
-    def __truediv__(self, other) -> "Quantity":  # type: ignore [empty-body]
-        ...  # pragma: no cover
-
-    @property
-    def attrs(self) -> Dict[Any, Any]:  # type: ignore [empty-body]
-        ...  # pragma: no cover
-
-    @property
-    def coords(  # type: ignore [empty-body]
-        self,
-    ) -> xarray.core.coordinates.DataArrayCoordinates:
-        ...  # pragma: no cover
-
-    @property
-    def dims(self) -> Tuple[Hashable, ...]:  # type: ignore [empty-body]
-        ...  # pragma: no cover
-
-    def assign_coords(
-        self,
-        coords: Optional[Mapping[Any, Any]] = None,
-        **coords_kwargs: Any,
-    ):
-        ...  # pragma: no cover
-
-    def bfill(  # type: ignore [empty-body]
-        self,
-        dim: Hashable,
-        limit: Optional[int] = None,
-    ) -> "Quantity":
-        ...  # pragma: no cover
-
-    def copy(
-        self,
-        deep: bool = True,
-        data: Any = None,
-    ):  # NB "Quantity" here offends mypy
-        ...  # pragma: no cover
-
-    def cumprod(  # type: ignore [empty-body]
-        self,
-        dim: Dims = None,
-        *,
-        skipna: Optional[bool] = None,
-        keep_attrs: Optional[bool] = None,
-        **kwargs: Any,
-    ):  # NB "Quantity" here offends mypy
-        ...  # pragma: no cover
-
-    def drop_vars(
-        self,
-        names: Union[Hashable, Iterable[Hashable]],
-        *,
-        errors="raise",
-    ):
-        ...  # pragma: no cover
-
-    def expand_dims(
-        self,
-        dim=None,
-        axis=None,
-        **dim_kwargs: Any,
-    ):  # NB "Quantity" here offends mypy
-        ...  # pragma: no cover
-
-    def ffill(  # type: ignore [empty-body]
-        self,
-        dim: Hashable,
-        limit: Optional[int] = None,
-    ) -> "Quantity":
-        ...  # pragma: no cover
-
-    def groupby(
-        self,
-        group,
-        squeeze: bool = True,
-        restore_coord_dims: bool = False,
-    ):
-        ...  # pragma: no cover
-
-    def interp(
-        self,
-        coords: Optional[Mapping[Any, Any]] = None,
-        method: InterpOptions = "linear",
-        assume_sorted: bool = False,
-        kwargs: Optional[Mapping[str, Any]] = None,
-        **coords_kwargs: Any,
-    ):
-        ...  # pragma: no cover
-
-    def item(self, *args):
-        ...  # pragma: no cover
-
-    def rename(
-        self,
-        new_name_or_name_dict: Union[Hashable, Mapping[Any, Hashable]] = None,
-        **names: Hashable,
-    ):  # NB "Quantity" here offends mypy
-        ...  # pragma: no cover
-
-    def sel(  # type: ignore [empty-body]
-        self,
-        indexers: Optional[Mapping[Any, Any]] = None,
-        method: Optional[str] = None,
-        tolerance=None,
-        drop: bool = False,
-        **indexers_kwargs: Any,
-    ) -> "Quantity":
-        ...  # pragma: no cover
-
-    def shift(
-        self,
-        shifts: Optional[Mapping[Hashable, int]] = None,
-        fill_value: Any = None,
-        **shifts_kwargs: int,
-    ):  # NB "Quantity" here offends mypy
-        ...  # pragma: no cover
-
-    def sum(
-        self,
-        dim: Dims = None,
-        # Signature from xarray.DataArray
-        *,
-        skipna: Optional[bool] = None,
-        min_count: Optional[int] = None,
-        keep_attrs: Optional[bool] = None,
-        **kwargs: Any,
-    ):  # NB "Quantity" here offends mypy
-        ...  # pragma: no cover
-
-    def round(self, *args, **kwargs):
-        ...  # pragma: no cover
-
-    def to_dataframe(
-        self,
-        name: Optional[Hashable] = None,
-        dim_order: Optional[Sequence[Hashable]] = None,
-    ) -> pd.DataFrame:
-        ...  # pragma: no cover
-
-    def to_numpy(self) -> np.ndarray:  # type: ignore [empty-body]
-        ...  # pragma: no cover
 
     # Internal methods
 

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -254,12 +254,8 @@ class Quantity:
 
             # Unpack a single column; use its name if not overridden by `name`
             return data.iloc[:, 0], (name or data.columns[0])
-        # NB would prefer to do this, but pandas has several bugs for MultiIndex with
-        #    only 1 level
-        # elif (
-        #     isinstance(data, pd.Series) and not isinstance(data.index, pd.MultiIndex)
-        # ):
-        #     return data.set_axis(pd.MultiIndex.from_product([data.index])), name
+        elif isinstance(data, pd.Series) and not isinstance(data.index, pd.MultiIndex):
+            return data.set_axis(pd.MultiIndex.from_product([data.index])), name
         else:
             return data, name
 

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -134,10 +134,27 @@ class Quantity:
     ):
         ...  # pragma: no cover
 
+    def bfill(  # type: ignore [empty-body]
+        self,
+        dim: Hashable,
+        limit: Optional[int] = None,
+    ) -> "Quantity":
+        ...  # pragma: no cover
+
     def copy(
         self,
         deep: bool = True,
         data: Any = None,
+    ):  # NB "Quantity" here offends mypy
+        ...  # pragma: no cover
+
+    def cumprod(  # type: ignore [empty-body]
+        self,
+        dim: Dims = None,
+        *,
+        skipna: Optional[bool] = None,
+        keep_attrs: Optional[bool] = None,
+        **kwargs: Any,
     ):  # NB "Quantity" here offends mypy
         ...  # pragma: no cover
 
@@ -155,6 +172,13 @@ class Quantity:
         axis=None,
         **dim_kwargs: Any,
     ):  # NB "Quantity" here offends mypy
+        ...  # pragma: no cover
+
+    def ffill(  # type: ignore [empty-body]
+        self,
+        dim: Hashable,
+        limit: Optional[int] = None,
+    ) -> "Quantity":
         ...  # pragma: no cover
 
     def groupby(

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -16,7 +16,7 @@ class Quantity(DataArrayLike["Quantity"]):
     """A sparse data structure that behaves like :class:`xarray.DataArray`.
 
     Depending on the value of :data:`CLASS`, Quantity is either :class:`.AttrSeries` or
-    :class:`SparseDataArray`.
+    :class:`.SparseDataArray`.
     """
 
     _name: Optional[Hashable]

--- a/genno/testing/__init__.py
+++ b/genno/testing/__init__.py
@@ -142,6 +142,7 @@ def add_test_data(c: Computer):
     x = Quantity(
         xr.DataArray(np.random.rand(len(t), len(y)), coords=[("t", t), ("y", y)]),
         units=ureg.kg,
+        name="Quantity X",
     )
 
     # Add, including sums and to index

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -47,7 +47,7 @@ class TestAttrSeries:
         _, result = q.align_levels(foo)
         assert ("a", "b") == result.dims
 
-    def test_cumprod(self, bar):
+    def test_cumprod(self, foo, bar):
         """AttrSeries.cumprod works with 1-dimensional quantities."""
         result0 = (1.1 + bar).cumprod("a")
         assert ("a",) == result0.dims
@@ -55,6 +55,10 @@ class TestAttrSeries:
         # Same result with dim=None
         result1 = (1.1 + bar).cumprod()
         pdt.assert_series_equal(result0, result1)
+
+        # But not with ≥1D
+        with pytest.raises(NotImplementedError):
+            foo.cumprod()
 
     def test_expand_dims(self, foo):
         # Name passes through expand_dims

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -55,6 +55,11 @@ class TestAttrSeries:
         result1 = (1.1 + bar).cumprod()
         pdt.assert_series_equal(result0, result1)
 
+    def test_expand_dims(self, foo):
+        # Name passes through expand_dims
+        result = foo.expand_dims(c=["c1", "c2"])
+        assert result.name == foo.name
+
     def test_interp(self, foo):
         with pytest.raises(NotImplementedError):
             foo.interp(coords=dict(a=["a1", "a1.5", "a2"], b=["b1", "b1.5", "b2"]))
@@ -130,7 +135,7 @@ class TestAttrSeries:
             bar.item()
 
 
-@pytest.mark.skip
+@pytest.mark.skip(reason="Slow, for benchmarking only")
 def test_sum_large(N_data=1e7):  # pragma: no cover
     """Test :meth:`.AttrSeries.sum` for large, sparse data."""
     # Create a single large AttrSeries

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -83,6 +83,10 @@ class TestAttrSeries:
         with pytest.raises(NotImplementedError):
             bar.sel(a="a2", tolerance=0.01)
 
+    def test_shift(self, foo):
+        foo.shift(a=1)
+        foo.shift(b=1)
+
     def test_squeeze(self, foo):
         assert foo.sel(a="a1").squeeze().dims == ("b",)
         assert foo.sel(a="a2", b="b1").squeeze().values == 2

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -12,7 +12,7 @@ class TestAttrSeries:
     @pytest.fixture
     def foo(self):
         idx = pd.MultiIndex.from_product([["a1", "a2"], ["b1", "b2"]], names=["a", "b"])
-        yield AttrSeries([0, 1, 2, 3], index=idx)
+        yield AttrSeries([0, 1, 2, 3], index=idx, name="Foo")
 
     @pytest.fixture
     def bar(self):
@@ -23,28 +23,29 @@ class TestAttrSeries:
         # Scalar vs scalar
         q = AttrSeries(0.1)
         other = AttrSeries(2.2)
-        result = q.align_levels(other)
+        _, result = q.align_levels(other)
         assert tuple() == result.dims
 
         # Scalar to 1D: broadcasts to 1D
-        result = q.align_levels(bar)
+        _, result = q.align_levels(bar)
         assert ("a",) == result.dims
         assert 1 == len(result.unique())
 
         # Scalar to 2D:
-        result = q.align_levels(foo)
-        assert ("a", "b") == result.dims
+        _, result = q.align_levels(foo)
+        assert ("b",) == result.dims
         assert 1 == len(result.unique())
 
         # 1D to scalar
-        result = bar.align_levels(q)
+        _, result = bar.align_levels(q)
         assert ("a",) == result.dims
 
         # 2D vs. 2D; same dimensions, different order
         idx = pd.MultiIndex.from_product([["b1", "b2"], ["a1", "a2"]], names=["b", "a"])
         q = AttrSeries([3, 2, 1, 0], index=idx)
         assert ("b", "a") == q.dims
-        assert ("a", "b") == q.align_levels(foo).dims
+        _, result = q.align_levels(foo)
+        assert ("a", "b") == result.dims
 
     def test_cumprod(self, bar):
         """AttrSeries.cumprod works with 1-dimensional quantities."""

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -489,7 +489,7 @@ def test_dantzig(ureg):
     d_i = c.get("d:i")
 
     # Units pass through summation
-    assert d_i.attrs["_unit"] == ureg.kilometre
+    assert d_i.units == ureg.kilometre
 
     # Summation across all dimensions results a 1-element Quantity
     d = c.get("d:")
@@ -527,7 +527,7 @@ def test_dantzig(ureg):
     b_jp = c.get("b:j-p")
 
     # Units pass through disaggregation
-    assert b_jp.attrs["_unit"] == ureg.case
+    assert b_jp.units == ureg.case
 
     # Set elements are available
     assert c.get("j") == ["new-york", "chicago", "topeka"]
@@ -644,7 +644,7 @@ def test_file_formats(test_data_path, tmp_path):
     assert_qty_equal(c.get(k), c.get(k2))
 
     # Units are loaded from a column
-    assert c.get(k2).attrs["_unit"] == pint.Unit("km")
+    assert c.get(k2).units == pint.Unit("km")
 
     # Specifying units that do not match file contents → ComputationError
     c.add_file(p2, key="bad", dims=dict(i="i", j_dim="j"), units="kg")
@@ -704,15 +704,15 @@ def test_units(ureg):
 
     # Aggregation preserves units
     c.add("energy", (computations.sum, "energy:x", None, ["x"]))
-    assert c.get("energy").attrs["_unit"] == ureg.parse_units("MJ")
+    assert c.get("energy").units == ureg.parse_units("MJ")
 
     # Units are derived for a ratio of two quantities
     c.add("power", (computations.ratio, "energy:x", "time"))
-    assert c.get("power").attrs["_unit"] == ureg.parse_units("MJ/hour")
+    assert c.get("power").units == ureg.parse_units("MJ/hour")
 
     # Product of dimensioned and dimensionless quantities keeps the former
     c.add("energy2", (computations.mul, "energy:x", "efficiency"))
-    assert c.get("energy2").attrs["_unit"] == ureg.parse_units("MJ")
+    assert c.get("energy2").units == ureg.parse_units("MJ")
 
 
 @pytest.mark.parametrize("suffix", [".json", ".yaml"])

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -512,6 +512,7 @@ def test_dantzig(ureg):
     exp = Quantity(
         (d_ij * weights).sum(dim=["j"]) / weights.sum(dim=["j"]).item(),
         attrs=d_ij.attrs,
+        name="d",
     )
 
     assert_qty_equal(exp, obs)

--- a/genno/tests/core/test_describe.py
+++ b/genno/tests/core/test_describe.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 import pytest
 
@@ -11,9 +13,11 @@ def test_describe():
     c.add("foo", Quantity(pd.Series([42, 43])))
 
     if Quantity._get_class() is SparseDataArray:
-        assert "\n".join(
-            ["'foo':", "- <xarray.SparseDataArray (index: 2)>"]
-        ) == c.describe("foo")
+        assert re.match(
+            r"""'foo':
+- <xarray\.SparseDataArray \([^:]+: 2\)>""",
+            c.describe("foo"),
+        )
 
 
 def test_describe_shorten():

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -17,7 +17,7 @@ from genno.core.quantity import assert_quantity, possible_scalar, unwrap_scalar
 from genno.core.sparsedataarray import SparseDataArray
 from genno.testing import add_large_data, assert_qty_allclose, assert_qty_equal
 
-pytsetmark = pytest.mark.usefixtures("parametrize_quantity_class")
+pytestmark = pytest.mark.usefixtures("parametrize_quantity_class")
 
 
 class TestQuantity:

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -195,24 +195,34 @@ class TestQuantity:
         assert ("phase", "p") == q0.dims
 
         # New dimension(s) without labels
-        q1 = a.expand_dims({"phase": []})
+        q1 = a.expand_dims(["phase"])
         assert ("phase", "p") == q1.dims
         assert 2 == q1.size
         assert (1, 2) == q1.shape
 
-        # NB this behaviour differs slightly from xr.DataArray.expand_dims()
-        # da = xr.DataArray([0.8, 0.2], coords=[["oil", "water"]], dims=["p"])
-        # assert (0, 2) == da.expand_dims({"phase": []}).shape  # Different result
-        # assert (1, 2) == da.expand_dims(["phase"]).shape  # Same result
+        # New dimension(s) without labels
+        q2 = a.expand_dims({"phase": []})
+        assert ("phase", "p") == q2.dims
+        if Quantity._get_class() is AttrSeries:
+            # NB this behaviour differs slightly from xr.DataArray.expand_dims()
+            assert (1, 2) == q2.shape
+            assert 2 == q2.size
+        else:
+            # da = xr.DataArray([0.8, 0.2], coords=[["oil", "water"]], dims=["p"])
+            # assert (0, 2) == da.expand_dims({"phase": []}).shape  # Different result
+            # assert (1, 2) == da.expand_dims(["phase"]).shape  # Same result
+
+            assert (0, 2) == q2.shape
+            assert 0 == q2.size
 
         # Multiple labels
-        q1 = a.expand_dims({"phase": ["liquid", "solid"]})
-        assert ("phase", "p") == q1.dims
-        assert all(["liquid", "solid"] == q1.coords["phase"])
+        q3 = a.expand_dims({"phase": ["liquid", "solid"]})
+        assert ("phase", "p") == q3.dims
+        assert all(["liquid", "solid"] == q3.coords["phase"])
 
         # Multiple dimensions and labels
-        q2 = a.expand_dims({"colour": ["red", "blue"], "phase": ["liquid", "solid"]})
-        assert ("colour", "phase", "p") == q2.dims
+        q4 = a.expand_dims({"colour": ["red", "blue"], "phase": ["liquid", "solid"]})
+        assert ("colour", "phase", "p") == q4.dims
 
     def test_ffill(self, tri):
         """Test Quantity.ffill()."""
@@ -338,7 +348,8 @@ class TestQuantity:
     "value",
     [
         2,
-        np.int64(2),
+        # Fails for SparseDataArray, not AttrSeries
+        pytest.param(np.int64(2), marks=pytest.mark.xfail(raises=ValueError)),
         1.1,
         np.float64(1.1),
         pytest.param([0.1, 2.3], marks=pytest.mark.xfail(raises=AssertionError)),

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -162,12 +162,12 @@ class TestQuantity:
         """Making a Quantity another produces a distinct attrs dictionary."""
         assert 0 == len(a.attrs)
 
-        a.attrs["_unit"] = pint.Unit("km")
+        a.units = pint.Unit("km")
 
         b = Quantity(a, units="kg")
-        assert pint.Unit("kg") == b.attrs["_unit"]
+        assert pint.Unit("kg") == b.units
 
-        assert pint.Unit("km") == a.attrs["_unit"]
+        assert pint.Unit("km") == a.units
 
     def test_cumprod(self, caplog, tri):
         """Test Quantity.cumprod()."""

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -669,3 +669,13 @@ def test_select(data):
 
     with pytest.raises(NotImplementedError):
         computations.select(x, indexers, inverse=True)
+
+
+@pytest.mark.parametrize("dimensions", (["t"], ["y"], ["t", "y"]))
+def test_sum(data, dimensions):
+    *_, t_foo, t_bar, x = data
+
+    # Function runs
+    result = computations.sum(x, dimensions=dimensions)
+
+    assert result.name == x.name and result.units == x.units  # Pass through

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -475,26 +475,36 @@ def test_mul0(func):
 
 @pytest.mark.parametrize("func", [computations.mul, computations.product])
 @pytest.mark.parametrize(
-    "dims, exp_size",
+    "dims, exp_dims, exp_shape",
     (
-        # Some overlapping dimensions
-        ((dict(a=2, b=2, c=2, d=2), dict(b=2, c=2, d=2, e=2, f=2)), 2**6),
+        # Scalar × scalar
+        (({}, {}), tuple(), tuple()),
+        # Scalar × 1D
+        (({}, dict(a=2)), ("a",), (2,)),
+        # 1D × scalar
+        ((dict(a=2), {}), ("a",), (2,)),
         # 1D with disjoint dimensions ** 3 = 3D
-        ((dict(a=2), dict(b=2), dict(c=2)), 2**3),
+        ((dict(a=2), dict(b=2), dict(c=2)), tuple("abc"), (2, 2, 2)),
         # 2D × scalar × scalar = 2D
-        ((dict(a=2, b=2), dict(), dict()), 4),
+        ((dict(a=2, b=2), {}, {}), tuple("ab"), (2, 2)),
         # scalar × 1D × scalar = 1D
-        # XFAIL for AttrSeries, XPASS for SparseDataArray
-        pytest.param((dict(), dict(a=2), dict()), 2, marks=pytest.mark.xfail),
+        (({}, dict(a=2), {}), tuple("a"), (2,)),
+        # 4D × 5D, with some overlapping dimensions
+        (
+            (dict(a=2, b=2, c=2, d=2), dict(b=2, c=2, d=2, e=2, f=2)),
+            tuple("abcdef"),
+            (2, 2, 2, 2, 2, 2),
+        ),
     ),
 )
-def test_mul1(func, dims, exp_size):
+def test_mul1(func, dims, exp_dims, exp_shape):
     """Product of quantities with disjoint and overlapping dimensions."""
     quantities = [random_qty(d) for d in dims]
 
     result = func(*quantities)
 
-    assert exp_size == result.size
+    assert exp_dims == result.dims
+    assert exp_shape == result.shape
 
 
 def test_pow(ureg):

--- a/genno/util.py
+++ b/genno/util.py
@@ -52,9 +52,10 @@ def collect_units(*args):
             log.debug(f"{arg} lacks units; assume dimensionless")
             unit = registry.dimensionless
 
-        arg.attrs["_unit"] = registry.Unit(unit)
+        # Convert a possible string or other expression to a pint.Unit object
+        arg.units = registry.Unit(unit)
 
-    return tuple(arg.attrs["_unit"] for arg in args)
+    return tuple(arg.units for arg in args)
 
 
 def filter_concat_args(args):


### PR DESCRIPTION
Changes in #85 resulted in downstream errors not caught by the genno test suite, cf. iiasa/message_data#442:
```
Computation traceback:
  File "/home/runner/work/message_data/message_data/message_data/message_data/model/transport/computations.py", line 509, in _advance_data_for
    computations.sum(result, dimensions=["n"]),
  File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/genno/computations.py", line 858, in sum
    return div(mul(quantity, _w).sum(dim=dimensions), w_total)
  File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/genno/core/attrseries.py", line 464, in sum
    raise ValueError(
ValueError: {'n'} not found in array dimensions [None]
```
This PR fixes the bug by improving dimension/index handling in the AttrSeries implementation of Quantity.

Also:
- Separate signatures/stub functions for Quantity that shadow xarray to a new class `.compat.xarray.DataClassLike` class. This leaves only methods with actual implementations in .quantity.Quantity.
  - Add stubs for .bfill, .cumprod, .ffill.
- Preserve Quantity name and units through more computations (aggregate, convert_units, sum) and test.
- Simplify basic mathematical computations (div, mul, pow) so that they are identical for AttrSeries and SparseDataArray.
- Internal clean-up:
  - Use `Quantity.units` wherever possible.
  - Ensure AttrSeries.index is always a pd.MultiIndex.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
