### PR TITLE
Adjust for Pint 0.22

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Adjust for changed exception types in Pint 0.22 (:pull:`90`).
 
 v1.17.0 (2023-05-15)
 ====================

--- a/genno/compat/pint.py
+++ b/genno/compat/pint.py
@@ -6,19 +6,24 @@ Notes:
   syntax), the exact exception raised by pint can sometimes vary between releases.
 - In pint 0.17, DefinitionSyntaxError is a subclass of SyntaxError.
   In pint 0.20, it is a subclass of ValueError.
+- In pint <0.22, certain expressions raise DefinitionSyntaxError.
+  In pint ≥0.22, they instead raise AssertionError.
 """
-from typing import Type
+from importlib.metadata import version
+from typing import Tuple, Type
 
 import pint
 
 try:
-    PintError: Type[Exception] = pint.PintError
+    PintError: Tuple[Type[Exception], ...] = (pint.PintError,)
     ApplicationRegistry: Type = pint.ApplicationRegistry
 except AttributeError:
     # Older versions of pint, e.g. 0.17
-    PintError = type("PintError", (Exception,), {})
+    PintError = (type("PintError", (Exception,), {}),)
     ApplicationRegistry = pint.UnitRegistry
 
+if version("Pint") >= "0.22":
+    PintError = PintError + (AssertionError,)
 
 __all__ = [
     "ApplicationRegistry",

--- a/genno/compat/pint.py
+++ b/genno/compat/pint.py
@@ -17,7 +17,7 @@ import pint
 try:
     PintError: Tuple[Type[Exception], ...] = (pint.PintError,)
     ApplicationRegistry: Type = pint.ApplicationRegistry
-except AttributeError:
+except AttributeError:  # pragma: no cover
     # Older versions of pint, e.g. 0.17
     PintError = (type("PintError", (Exception,), {}),)
     ApplicationRegistry = pint.UnitRegistry

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -530,7 +530,7 @@ def interpolate(
 def load_file(
     path: Path,
     dims: Union[Collection[Hashable], Mapping[Hashable, Hashable]] = {},
-    units: UnitLike = None,
+    units: Optional[UnitLike] = None,
     name: Optional[str] = None,
 ) -> Any:
     """Read the file at *path* and return its contents as a :class:`.Quantity`.
@@ -578,7 +578,7 @@ UNITS_RE = re.compile(r"# Units?: (.*)\s+")
 def _load_file_csv(
     path: Path,
     dims: Union[Collection[Hashable], Mapping[Hashable, Hashable]] = {},
-    units: UnitLike = None,
+    units: Optional[UnitLike] = None,
     name: Optional[str] = None,
 ) -> Quantity:
     # Peek at the header, if any, and match a units expression

--- a/genno/tests/test_util.py
+++ b/genno/tests/test_util.py
@@ -6,6 +6,7 @@ import pytest
 from dask.core import quote
 
 from genno import Key, Quantity
+from genno.compat.pint import PintError
 from genno.testing import assert_logs
 from genno.util import (
     clean_units,
@@ -85,7 +86,8 @@ def test_parse_units1(ureg, caplog):
     """Multiple attempts to (re)define new units."""
     parse_units("JPY")
     parse_units("GBP/JPY")
-    with pytest.raises(pint.DefinitionSyntaxError):
+
+    with pytest.raises(PintError, match="cannot be parsed; contains invalid character"):
         parse_units("GBP/JPY/$?")
 
 

--- a/genno/util.py
+++ b/genno/util.py
@@ -140,7 +140,7 @@ def parse_units(data: Iterable, registry=None) -> pint.Unit:
         except PintError as e:
             # registry.define() failed somehow
             raise invalid(unit, e)
-    except (AttributeError, TypeError, PintError) as e:
+    except (AttributeError, TypeError) + PintError as e:  # type: ignore [misc]
         # Unit contains a character like '-' that throws off pint
         # NB this 'except' clause must be *after* UndefinedUnitError, since that is a
         #    subclass of AttributeError.


### PR DESCRIPTION
Pint 0.22 ([released 2023-05-25](https://github.com/hgrecco/pint/blob/3fb63af49df803e7bcad1fe9e6bdaab04021f4cc/CHANGES#L10-L22)) once again changed the types of exceptions raised, so that:

```py
parse_units("GBP/JPY/$?")
```
…now raises AssertionError instead of pint.DefinitionSyntaxError as in Pint < 0.22. See [here](https://github.com/khaeru/genno/actions/runs/5117745150/jobs/9201110744#step:6:921) for one example. This causes failures of the "pytest" CI workflow on all Pythons >= 3.9.

This PR adjusts.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- [x] Update doc/whatsnew.rst
