### PR TITLE
Update intersphinx links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,7 @@ extlinks_detect_hardcoded_links = False
 
 intersphinx_mapping = {
     "dask": ("https://docs.dask.org/en/stable/", None),
+    "genno": ("https://genno.readthedocs.io/en/latest", None),
     "ixmp": ("https://docs.messageix.org/projects/ixmp/en/latest", None),
     "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
     "graphviz": ("https://graphviz.readthedocs.io/en/stable/", None),

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -89,8 +89,8 @@ class Computer:
         Messages are logged at level :data:`logging.INFO` if `config` contains
         unhandled sections.
 
-        See :doc:`genno:config` for a list of all configuration sections and keys, and details
-        of the configuration file format.
+        See :doc:`genno:config` for a list of all configuration sections and keys,
+         and details of the configuration file format.
 
         Parameters
         ----------

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -89,7 +89,7 @@ class Computer:
         Messages are logged at level :data:`logging.INFO` if `config` contains
         unhandled sections.
 
-        See :doc:`config` for a list of all configuration sections and keys, and details
+        See :doc:`genno:config` for a list of all configuration sections and keys, and details
         of the configuration file format.
 
         Parameters
@@ -274,7 +274,7 @@ class Computer:
 
         See also
         --------
-        :doc:`cache`
+        :doc:`genno:cache`
         """
         return caching.decorate(func, computer=self)
 


### PR DESCRIPTION
As I discovered while trying to build the message_ix docs locally, two links in core/computer.py were broken: `:doc:'cache'` and `:doc:'config'`. As suggested by @khaeru, this PR provides explicit links for both of them, which only requires adding `genno:` since that is already mapped in `doc/conf.py`. 

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- ~[ ] Update doc/whatsnew.rst~
