### PR TITLE
Add an Operator class

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,6 +9,8 @@ comment:
 coverage:
   status:
     project:
-      default: {}
+      default:
+        if_ci_failed: success
     patch:
-      default: {}
+      default:
+        if_ci_failed: success

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,5 +18,6 @@ jobs:
         nbclient
         "pint < 0.21"
         pytest
+        Sphinx
         types-PyYAML
         xarray

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,10 +18,10 @@ Top-level classes and functions
 
 .. autoclass:: genno.Computer
    :members:
-   :exclude-members: add, add_as_pyam, add_load_file, apply, convert_pyam, eval, graph
+   :exclude-members: add, apply, eval, graph
 
-   A Computer is used to describe (:meth:`add` and related methods) and then execute (:meth:`get` and related methods) **tasks** stored in a :attr:`graph`.
-   Advanced users may manipulate the graph directly; but common reporting tasks can be handled by using Computer methods.
+   A Computer is used to prepare (:meth:`add` and related methods) and then execute (:meth:`get` and related methods) **computations** stored in a :attr:`graph`.
+   Advanced users may manipulate the graph directly; but most computations can be prepared can be handled by using Computer methods.
 
    Instance attributes:
 
@@ -32,28 +32,20 @@ Top-level classes and functions
       modules
       unit_registry
 
-   General-purpose methods for describing tasks and preparing computations:
+   General-purpose methods for preparing computations and tasks:
 
    .. autosummary::
       add
       add_queue
       add_single
+      aggregate
       apply
       cache
       describe
       eval
       visualize
 
-   Helper methods to simplify adding specific computations:
-
-   .. autosummary::
-      add_file
-      add_product
-      aggregate
-      convert_pyam
-      disaggregate
-
-   Executing tasks:
+   Executing computations:
 
    .. autosummary::
       get
@@ -68,6 +60,14 @@ Top-level classes and functions
       get_comp
       infer_keys
       require_compat
+
+   Deprecated:
+
+   .. autosummary::
+      add_file
+      add_product
+      convert_pyam
+      disaggregate
 
    .. autoattribute:: graph
 
@@ -86,8 +86,7 @@ Top-level classes and functions
       ``"config"``
          A :class:`dict` storing configuration settings.
          See :doc:`config`.
-         Because this information is stored *in* the :attr:`graph`, it can be
-         used as one input to other computations.
+         Because this information is stored *in* the :attr:`graph`, it can be used as one input to other computations.
 
       Some inputs to tasks may be confused for (1) or (4), above.
       The recommended way to protect these is:
@@ -103,9 +102,9 @@ Top-level classes and functions
       :class:`list`
          A list of computations, like ``[(list(args1), dict(kwargs1)), (list(args2), dict(kwargs2)), ...]`` → passed to :meth:`add_queue`.
 
-      :class:`str` naming a computation
+      :class:`str` naming an operator
          e.g. "select", retrievable with :meth:`get_comp`.
-         :meth:`add_single` is called with ``(key=args[0], data, *args[1], **kwargs``, i.e. applying the named computation. to the other parameters.
+         :meth:`add_single` is called with ``(key=args[0], data, *args[1], **kwargs``, i.e. applying the named operator to the other parameters.
 
       :class:`str` naming another Computer method
          e.g. :meth:`add_file` → the named method is called with the `args` and `kwargs`.
@@ -121,8 +120,7 @@ Top-level classes and functions
         >>> rep = Computer()  # Create a new Computer object
         >>> rep.add('aliased name', 'original name')
 
-      - Define an arbitrarily complex computation in a Python function that
-        operates directly on the :class:`ixmp.Scenario`:
+      - Define an arbitrarily complex operator in a Python function that operates directly on the :class:`ixmp.Scenario`:
 
         >>> def my_report(scenario):
         >>>     # many lines of code
@@ -293,20 +291,20 @@ Common :mod:`genno` usage, e.g. in :mod:`message_ix`, creates large, sparse data
 - Currently, Quantity is :class:`.AttrSeries`, a wrapped :class:`pandas.Series` that behaves like a :class:`~xarray.DataArray`.
 - In the future, :mod:`genno` will use :class:`.SparseDataArray`, and eventually :class:`~xarray.DataArray` backed by sparse data, directly.
 
-The goal is that all :mod:`genno`-based code, including built-in and user computations, can treat quantity arguments as if they were :class:`~xarray.DataArray`.
+The goal is that all :mod:`genno`-based code, including built-in and user functions, can treat quantity arguments as if they were :class:`~xarray.DataArray`.
 
 
-Computations
-============
+Operators
+=========
 
 .. automodule:: genno.computations
    :members:
 
-   Unless otherwise specified, these methods accept and return :class:`.Quantity` objects for data arguments/return values.
+   Unless otherwise specified, these functions accept and return :class:`.Quantity` objects for data arguments/return values.
 
-   Genno's :ref:`compatibility modules <compat>` each provide additional computations.
+   Genno's :ref:`compatibility modules <compat>` each provide additional operators.
 
-   Numerical calculations:
+   Numerical operators:
 
    .. autosummary::
       add
@@ -319,6 +317,7 @@ Computations
       index_to
       interpolate
       mul
+      add_mul
       pow
       product
       ratio
@@ -329,6 +328,7 @@ Computations
 
    .. autosummary::
       load_file
+      add_load_file
       write_report
 
    Data manipulation:
@@ -341,6 +341,12 @@ Computations
       relabel
       rename_dims
       select
+
+Helper functions for adding tasks to Computers
+----------------------------------------------
+
+.. autofunction:: add_load_file
+.. autofunction:: add_mul
 
 
 Internal format for quantities
@@ -386,6 +392,9 @@ Internals and utilities
    :members:
 
 .. automodule:: genno.core.graph
+   :members:
+
+.. automodule:: genno.core.operator
    :members:
 
 .. automodule:: genno.util

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -100,11 +100,11 @@ Top-level classes and functions
       The `data` argument may be:
 
       :class:`list`
-         A list of computations, like ``[(list(args1), dict(kwargs1)), (list(args2), dict(kwargs2)), ...]`` → passed to :meth:`add_queue`.
+         A list of computations, like :py:`[(list(args1), dict(kwargs1)), (list(args2), dict(kwargs2)), ...]` → passed to :meth:`add_queue`.
 
       :class:`str` naming an operator
          e.g. "select", retrievable with :meth:`get_comp`.
-         :meth:`add_single` is called with ``(key=args[0], data, *args[1], **kwargs``, i.e. applying the named operator to the other parameters.
+         :meth:`add_single` is called with :py:`(key=args[0], data, *args[1], **kwargs)`, that is, applying the named operator to the other parameters.
 
       :class:`str` naming another Computer method
          e.g. :meth:`add_file` → the named method is called with the `args` and `kwargs`.
@@ -265,6 +265,8 @@ Common :mod:`genno` usage, e.g. in :mod:`message_ix`, creates large, sparse data
 
 The goal is that all :mod:`genno`-based code, including built-in and user functions, can treat quantity arguments as if they were :class:`~xarray.DataArray`.
 
+.. automodule:: genno
+   :members: MissingKeyError
 
 Operators
 =========
@@ -365,6 +367,9 @@ Internals and utilities
 
 .. automodule:: genno.core.graph
    :members:
+
+.. automodule:: genno.core.key
+   :members: KeyLike, iter_keys, single_key
 
 .. automodule:: genno.core.operator
    :members:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -154,34 +154,6 @@ Top-level classes and functions
 
          rep.apply(my_gen1, units="kg")
 
-   .. automethod:: convert_pyam
-
-      The :doc:`IAMC data format <pyam:data>` includes columns named 'Model', 'Scenario', 'Region', 'Variable', 'Unit'; one of 'Year' or 'Time'; and 'value'.
-
-      Using :meth:`convert_pyam`:
-
-      - 'Model' and 'Scenario' are populated from the attributes of the object returned by the Reporter key ``scenario``;
-      - 'Variable' contains the name(s) of the `quantities`;
-      - 'Unit' contains the units associated with the `quantities`; and
-      - 'Year' or 'Time' is created according to `year_time_dim`.
-
-      A callback function (`collapse`) can be supplied that modifies the data before it is converted to an :class:`~pyam.IamDataFrame`; for instance, to concatenate extra dimensions into the 'Variable' column.
-      Other dimensions can simply be dropped (with `drop`).
-      Dimensions that are not collapsed or dropped will appear as additional columns in the resulting :class:`~pyam.IamDataFrame`; this is valid, but non-standard IAMC data.
-
-      For example, here the values for the MESSAGEix ``technology`` and ``mode`` dimensions are appended to the 'Variable' column:
-
-      .. code-block:: python
-
-          def m_t(df):
-              """Callback for collapsing ACT columns."""
-              # .pop() removes the named column from the returned row
-              df['variable'] = 'Activity|' + df['t'] + '|' + df['m']
-              return df
-
-          ACT = rep.full_key('ACT')
-          keys = rep.convert_pyam(ACT, 'ya', collapse=m_t, drop=['t', 'm'])
-
    .. automethod:: eval
 
       .. rubric:: Examples

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -297,6 +297,7 @@ Operators
       ratio
       sub
       sum
+      add_sum
 
    Input and output:
 

--- a/doc/cache.rst
+++ b/doc/cache.rst
@@ -4,7 +4,7 @@ Caching
 Basics
 ======
 
-Use :meth:`.Computer.cache` to decorate another function, `func`, that will be added as the computation/callable in a task.
+Use :meth:`.Computer.cache` to decorate another function, `func`, that will be added as the operator/callable in a task.
 Caching is useful when :meth:`.get` is called multiple times on the same Computer, or across processes, invoking a slow `func` each time.
 
 .. code-block:: python
@@ -85,7 +85,7 @@ Another possibility is to hash the entire file.
 
 .. warning:: For very large files, even hashing the file in this way can be slow, and this check must *always* be performed in order to check for a matching cache key.
 
-The decorated functions can be used as computations in the graph, or called directly:
+The decorated functions can be used as operators in the graph, or called directly:
 
 .. code-block:: python
 

--- a/doc/compat-plotnine.rst
+++ b/doc/compat-plotnine.rst
@@ -51,7 +51,7 @@ To use :class:`.Plot`:
       c.add("y:t", Quantity(xr.DataArray([1.0, 4, 9], coords=t), name="y"))
 
       # Add the plot to the Computer
-      c.add("plot", DemoPlot.make_task("x:t", "y:t"))
+      c.add("plot", DemoPlot, "x:t", "y:t")
 
       # Show the task that was added
       c.graph["plot"]

--- a/doc/compat-pyam.rst
+++ b/doc/compat-pyam.rst
@@ -9,43 +9,89 @@ Pyam (:mod:`.compat.pyam`)
    :members:
    :exclude-members: iamc
 
+   The :doc:`“IAMC data structure” <pyam:data>` is a particular data structure with either 6 or 7 dimensions: ``model``, ``scenario``, ``region``, ``variable``, ``unit``, either ``year`` or ``time``, and optionally ``subannual``.
+   Data with this structure are usually stored in a tablular “IAMC format,” wherein each dimension is stored as one column, and the remaining column, labeled ``value``, contains observation values.
+
+   Using :func:`.add_as_pyam` (:py:`Computer.add(..., "as_pyam", ...)`):
+
+   - ``model`` and ``scenario`` are populated from the attributes of the object returned by the Computer key ``scenario``;
+   - ``variable`` contains the name(s) of each of the `quantities`, or others constructed by `collapse` (see below);
+   - ``unit`` contains the units associated with each of the `quantities`; and
+   - ``year``, ``time``, and optionally ``subannual`` can be created using `rename` or `collapse` operations.
+
+   A callback function (`collapse`) can be supplied that modifies the data before it is converted to an :class:`~pyam.IamDataFrame`; for instance, to concatenate extra dimensions into ``variable`` labels.
+   Other dimensions can simply be dropped (with `drop`).
+   Dimensions that are not collapsed or dropped will appear as additional columns in the resulting :class:`~pyam.IamDataFrame`; this is valid, but non-standard data per the IAMC format.
+
+   For example, here the labels for the MESSAGEix ``t`` (technology) and ``m`` (mode) dimensions are appended to a fixed string to construct ``variable`` labels:
+
+   .. code-block:: python
+
+      c = Computer
+
+      def m_t(df):
+         """Collapse `t` and `m` dimensions to an IAMC 'Variable' string."""
+         df["variable"] = "Activity|" + df["t"] + "|" + df["m"]
+         return df
+
+      ACT = c.full_key('ACT')
+      keys = c.add(ACT, "as_pyam", "ya", collapse=m_t, drop=["t", "m"])
+
+
 .. automodule:: genno.compat.pyam.computations
    :members:
 
-.. automodule:: genno.compat.pyam.util
-   :members:
+   .. autosummary::
+
+      as_pyam
+      add_as_pyam
+      concat
+      write_report
+
+   .. .. autofunction:: as_pyam
+
+   .. autofunction:: add_as_pyam
 
 .. _config-pyam:
 
 Configuration
 =============
 
-:mod:`.compat.pyam` adds a ``iamc:`` configuration file section.
+:mod:`.compat.pyam` adds a handler for a ``iamc:`` configuration file section.
 
 .. automethod:: genno.compat.pyam.iamc
 
-Computer-specific configuration.
+   Computer-specific configuration.
 
-Invokes :meth:`.Computer.convert_pyam` (plus extra computations) to reformat data from :class:`.Quantity` into a :class:`pyam.IamDataFrame` data structure.
-Each entry contains:
+   Invokes :meth:`.add_as_pyam` and adds additional computations to convert data from :class:`.Quantity` to a :class:`pyam.IamDataFrame`.
+   Each entry contains:
 
-``variable:`` (:class:`str`)
-   Variable name.
-   This is used two ways: it is placed in 'Variable' column of the resulting IamDataFrame; and the reporting key to :meth:`~.Computer.get` the data frame is ``<variable>:iamc``.
-``base:`` (:class:`str`)
-   Key for the quantity to convert.
-``select:`` (:class:`dict`, optional)
-   Keyword arguments to :func:`.computations.select`.
-``rename:`` (:class:`dict`, optional)
-   Passed to :meth:`convert_pyam`.
-``replace:`` (:class:`dict`, optional)
-   Passed to :meth:`.convert_pyam`.
-``drop:`` (:class:`list` of :class:`str`, optional)
-   Dimensions to drop (→ convert_pyam).
-``unit:`` (:class:`str`, optional)
-   Force output in these units (→ convert_pyam).
+   ``variable:`` (:class:`str`)
+      Variable name.
+      This is used two ways: it is placed in the ``variable`` label of the resulting IamDataFrame; and the Computer key for executing the conversion is ``<variable>:iamc``.
+   ``base:`` (:class:`str`)
+      Key for the quantity to convert.
+   ``select:`` (:class:`dict`, optional)
+      Keyword arguments to :func:`.computations.select`.
+      This selection is performed while data is in :class:`.Quantity` format, before it is passed to :func:`.as_pyam`.
+   ``rename:`` (:class:`dict`, optional)
+      Passed to :meth:`.as_pyam`.
+   ``replace:`` (:class:`dict`, optional)
+      Passed to :meth:`.as_pyam`.
+   ``drop:`` (:class:`list` of :class:`str`, optional)
+      Passed to :meth:`.as_pyam`.
+   ``unit:`` (:class:`str`, optional)
+      Passed to :meth:`.as_pyam`.
 
-Additional entries are passed as keyword arguments to :func:`.collapse`, which is then given as the `collapse` callback for :meth:`.convert_pyam`.
+   Any further additional entries are passed as keyword arguments to :func:`.collapse`, which is then given as the `collapse` callback for :meth:`.as_pyam`.
 
-:func:`.collapse` formats the 'Variable' column of the IamDataFrame.
-The variable name replacements from the ``iamc variable names:`` section of the config file are applied to all variables.
+   :func:`.collapse` formats the ``variable`` labels of the IamDataFrame.
+   The variable name replacements from the ``iamc variable names:`` section of the config file are applied to all variables.
+
+Utilities
+=========
+
+.. currentmodule:: genno.compat.pyam.util
+
+.. automodule:: genno.compat.pyam.util
+   :members:

--- a/doc/compat-pyam.rst
+++ b/doc/compat-pyam.rst
@@ -63,7 +63,7 @@ Configuration
 
    Computer-specific configuration.
 
-   Invokes :meth:`.add_as_pyam` and adds additional computations to convert data from :class:`.Quantity` to a :class:`pyam.IamDataFrame`.
+   Invokes :func:`.add_as_pyam` and adds additional computations to convert data from :class:`.Quantity` to a :class:`pyam.IamDataFrame`.
    Each entry contains:
 
    ``variable:`` (:class:`str`)
@@ -75,15 +75,15 @@ Configuration
       Keyword arguments to :func:`.computations.select`.
       This selection is performed while data is in :class:`.Quantity` format, before it is passed to :func:`.as_pyam`.
    ``rename:`` (:class:`dict`, optional)
-      Passed to :meth:`.as_pyam`.
+      Passed to :func:`.as_pyam`.
    ``replace:`` (:class:`dict`, optional)
-      Passed to :meth:`.as_pyam`.
+      Passed to :func:`.as_pyam`.
    ``drop:`` (:class:`list` of :class:`str`, optional)
-      Passed to :meth:`.as_pyam`.
+      Passed to :func:`.as_pyam`.
    ``unit:`` (:class:`str`, optional)
-      Passed to :meth:`.as_pyam`.
+      Passed to :func:`.as_pyam`.
 
-   Any further additional entries are passed as keyword arguments to :func:`.collapse`, which is then given as the `collapse` callback for :meth:`.as_pyam`.
+   Any further additional entries are passed as keyword arguments to :func:`.collapse`, which is then given as the `collapse` callback for :func:`.as_pyam`.
 
    :func:`.collapse` formats the ``variable`` labels of the IamDataFrame.
    The variable name replacements from the ``iamc variable names:`` section of the config file are applied to all variables.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,12 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
+rst_prolog = """
+.. role:: py(code)
+   :language: python
+"""
+
+
 def setup(app):
     """Modify the sphinx.ext.autodoc config to handle Operators as functions."""
     from sphinx.ext.autodoc import FunctionDocumenter

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,24 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
+def setup(app):
+    """Modify the sphinx.ext.autodoc config to handle Operators as functions."""
+    from sphinx.ext.autodoc import FunctionDocumenter
+
+    from genno.core.operator import Operator
+
+    class OperatorDocumenter(FunctionDocumenter):
+        # priority = FunctionDocumenter.priority - 1
+
+        @classmethod
+        def can_document_member(cls, member, membername, isattr, parent) -> bool:
+            return isinstance(member, Operator) or super().can_document_member(
+                member, membername, isattr, parent
+            )
+
+    app.add_autodocumenter(OperatorDocumenter, override=True)
+
+
 # -- Options for HTML output -----------------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for a list of

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -297,7 +297,7 @@ This is, as the name implies, the most generalized section.
 Each item contains:
 
 ``comp:``
-  Refers to the name of a computation that is available in the namespace of :mod:`genno.computations`, or custom computations registered by compatibility modules or third-party packages.
+  Refers to the name of a operator that is available in the namespace of :mod:`genno.computations`, or a custom operator registered by compatibility modules or third-party packages.
   See :meth:`Computer.add` and :meth:`Computer.get_comp`.
   E.g. if "product", then :meth:`.Computer.add_product` is called, which also automatically infers the correct dimensions for each input.
 
@@ -308,9 +308,9 @@ Each item contains:
 
    If the key has the single dimension "\*" (e.g. ``key: "X:*:tag"``), then dimensions of the resulting key are inferred to be the union of the dimensions of each of the ``inputs:``, below.
 ``inputs:``
-   A list of (1 or more) keys to which the computation is applied.
+   A list of (1 or more) keys to which the operator is applied.
 ``args:`` (:class:`dict`, optional)
-   Keyword arguments to the computation.
+   Keyword arguments to the operator.
 ``add args:`` (:class:`dict`, optional)
    Keyword arguments to :meth:`.Computer.add` itself.
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -206,7 +206,7 @@ Computer-specific configuration that controls the behaviour of functions decorat
 
 Computer-specific configuration.
 
-Invokes :meth:`.Computer.add_combination` to add tasks with :func:`computations.combine`, computing a weighted sum of multiple Quantities.
+Add tasks with :func:`.combine`, computing a weighted sum of multiple Quantities.
 Each item contains:
 
 ``key:``
@@ -217,7 +217,7 @@ Each item contains:
 
   ``quantity:`` (required)
      Key for the input quantity.
-     :meth:`.add_combination` infers the proper dimensionality from the dimensions of `key` plus dimension to `select` on.
+     The final dimensionality is inferred from the dimensions of `key` plus dimension to `select` on.
   ``select:`` (:class:`dict`, optional)
      Selectors to be applied to the input quantity.
      Keys are dimensions; values are either single labels, or lists of labels.
@@ -240,7 +240,7 @@ For the following YAML:
      - quantity: baz::tag
        select: {d: [d1, d2, d3]}
 
-…:meth:`.add_combination` infers:
+The code infers:
 
 .. math::
 
@@ -298,10 +298,10 @@ Each item contains:
 
 ``comp:``
   Refers to the name of a operator that is available in the namespace of :mod:`genno.computations`, or a custom operator registered by compatibility modules or third-party packages.
-  See :meth:`Computer.add` and :meth:`Computer.get_comp`.
-  E.g. if "product", then :meth:`.Computer.add_product` is called, which also automatically infers the correct dimensions for each input.
+  See :meth:`.Computer.add` and :meth:`.Computer.get_comp`.
+  For instance, if "product", then :meth:`.Computer.add_product` is called, which also automatically infers the correct dimensions for each input.
 
-  If omitted, :data:`None`, or YAML ``null``, no specific callable is used, but instead ``key:`` is configured to retrieve a simple :class:`list`` of the ``inputs:``.
+  If omitted, :data:`None`, or YAML ``null``, no specific callable is used, but instead ``key:`` is configured to retrieve a simple :class:`list` of the ``inputs:``.
   In this case, ``args:`` are ignored.
 ``key:``
    The key for the computed quantity.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,10 +20,10 @@ genno is built on high-quality Python data packages including ``dask``, ``xarray
 Compatibility
 =============
 
-:mod:`genno` provides built-in support for interaction with:
+:mod:`.genno` provides built-in support for interaction with:
 
-- :doc:`Plotnine <compat-plotnine>` (:mod:`plotnine`), via :mod:`.compat.plotnine`.
-- :doc:`Pyam <compat-pyam>` (:mod:`pyam`), via :mod:`.compat.pyam`.
+- :doc:`Plotnine <compat-plotnine>` (:mod:`.plotnine`), via :mod:`.compat.plotnine`.
+- :doc:`Pyam <compat-pyam>` (:mod:`.pyam`), via :mod:`.compat.pyam`.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -148,7 +148,7 @@ This means:
 - Every edge has a direction; *from* one node *to* another.
 - There are no recursive loops in the graph; i.e. no node is its own ancestor.
 
-In the reporting graph, every node represents a **computation**; usually a :class:`tuple` called a **task** wherein the first element is a :class:`callable` like a function.
+In the reporting graph, every node represents a **computation**; usually a :class:`tuple` called a **task** wherein the first element is a :func:`callable` like a function.
 This callable can be:
 
 - a numerical *calculation* operating on one or more Quantities;
@@ -157,7 +157,7 @@ This callable can be:
 Other elements in the task tuple are passed, in the same order, as positional arguments to the callable.
 
 .. note::
-   :mod:`genno` relies on the :mod:`dask` implementation of task graphs.
+   :mod:`genno` relies on the :mod:`.dask` implementation of task graphs.
    For a complete description of tasks, see the :doc:`dask:spec` in the dask documentation.
 
 Every node has a unique *label*, describing the results of its task.
@@ -205,15 +205,15 @@ To describe this using the Computer (step 1):
 
 To unpack this code:
 
-- :meth:`Computer.add` is used to build the graph.
-- The first argument to :meth:`add` is the label or key of the node; the description of what it will produce.
+- :meth:`.Computer.add` is used to build the graph.
+- The first argument to :meth:`.add` is the label or key of the node; the description of what it will produce.
 - The following arguments describe the computation (for instance, a task with a specific operator) to be performed:
 
   - For nodes ‘A’ and ‘B’, these are simply a raw or literal value.
     When the node is executed, this value is returned.
-  - For node ‘C’, it is a :class:`tuple` with 3 items: ``(lambda *inputs: sum(inputs), 'A', 'B')``.
+  - For node ‘C’, it is a :class:`tuple` with 3 items: :py:`(lambda *inputs: sum(inputs), 'A', 'B')`.
 
-    1. ``lambda *inputs: sum(inputs)``, is an `anonymous or ‘lambda’ function <https://doc.python.org/3/tutorial/controlflow.html#lambda-expressions>`_ that computes the sum of its inputs.
+    1. :py:`lambda *inputs: sum(inputs)`, is an `anonymous or ‘lambda’ function <https://doc.python.org/3/tutorial/controlflow.html#lambda-expressions>`_ that computes the sum of its inputs.
     2. The label ``"A"`` is a reference to another node. This indicates that there is a graph edge from node ``"A"`` into node ``"C"``.
     3. Same as (2)
 
@@ -229,7 +229,7 @@ The task to produce "C", and any direct or indirect inputs required, is executed
 
     c.get("C")
 
-:meth:`Computer.describe` displays a simple textual trace of the tasks used in this chain of computations.
+:meth:`.Computer.describe` displays a simple textual trace of the tasks used in this chain of computations.
 A portion of the graph is printed out as a nested list:
 
 .. ipython:: python
@@ -241,9 +241,9 @@ This description shows how :mod:`genno` traverses the graph in order to calculat
 1. The desired value is from node "C", which computes a function of some arguments.
 2. The first argument is ``"A"``.
 3. "A" is the name of another node.
-4. Node "A" gives a literal value ``int(1)``, which is stored.
+4. Node "A" gives a literal value :py:`int(1)`, which is stored.
 5. The Computer returns to "C" and moves on to the next argument, "B".
-6. Steps 3 and 4 are repeated for "B", giving ``int(2)``.
+6. Steps 3 and 4 are repeated for "B", giving :py:`int(2)`.
 7. All of the arguments to "C" have been processed.
 8. The function/operator for "C" is called.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -148,11 +148,11 @@ This means:
 - Every edge has a direction; *from* one node *to* another.
 - There are no recursive loops in the graph; i.e. no node is its own ancestor.
 
-In the reporting graph, every node represents a **task**, usually a :class:`tuple` wherein the first element is a :class:`callable` like a function.
+In the reporting graph, every node represents a **computation**; usually a :class:`tuple` called a **task** wherein the first element is a :class:`callable` like a function.
 This callable can be:
 
 - a numerical *calculation* operating on one or more Quantities;
-- more generally, a *computation*, including other actions like transforming data formats, reading and writing files, writing plots, etc.
+- more generally, an *operator*, including other actions like transforming data formats, reading and writing files, writing plots, etc.
 
 Other elements in the task tuple are passed, in the same order, as positional arguments to the callable.
 
@@ -207,7 +207,7 @@ To unpack this code:
 
 - :meth:`Computer.add` is used to build the graph.
 - The first argument to :meth:`add` is the label or key of the node; the description of what it will produce.
-- The following arguments describe the task, calculation, or computation to be performed:
+- The following arguments describe the computation (for instance, a task with a specific operator) to be performed:
 
   - For nodes ‘A’ and ‘B’, these are simply a raw or literal value.
     When the node is executed, this value is returned.
@@ -229,7 +229,7 @@ The task to produce "C", and any direct or indirect inputs required, is executed
 
     c.get("C")
 
-:meth:`Computer.describe` displays a simple textual trace of the tasks used in this computation.
+:meth:`Computer.describe` displays a simple textual trace of the tasks used in this chain of computations.
 A portion of the graph is printed out as a nested list:
 
 .. ipython:: python
@@ -245,7 +245,7 @@ This description shows how :mod:`genno` traverses the graph in order to calculat
 5. The Computer returns to "C" and moves on to the next argument, "B".
 6. Steps 3 and 4 are repeated for "B", giving ``int(2)``.
 7. All of the arguments to "C" have been processed.
-8. The computation function for "C" is called.
+8. The function/operator for "C" is called.
 
    As arguments, instead of the strings "A" and "B", this function receives the computed :class:`int` values from steps 4 and 6 respectively.
 9. The result is returned.
@@ -258,11 +258,11 @@ In more realistic examples, the graph can have:
 
 However, the Computer still follows the same procedure to traverse the graph and calculate the results.
 
-Computations
-============
+Operators
+=========
 
-A computation is any Python function or callable that operates on Quantities or other data.
-:mod:`genno.computations` includes many common computations; see the API documentation for descriptions of each.
+A operator is any Python function or callable that operates on Quantities or other data.
+:mod:`genno.computations` includes many common operators; see the API documentation for descriptions of each.
 
 The power of :mod:`genno` is the ability to link *any* code, no matter how complex, into the graph, and have it operate on the results of other code.
 Tasks can perform complex tasks such as:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -38,7 +38,11 @@ All changes
   This class allows to combine a function/callable for use in computations with an optional :meth:`~.Operator.helper` convenience method for adding tasks to a :class:`.Computer`.
   :meth:`.Computer.add` calls these helpers automatically, if they exist.
 - New method :meth:`.Computer.eval` for using Python code-like expressions to define tasks and keys (:pull:`97`).
-- Add :meth:`.Key.rename` (:pull:`98`).
+- Improve :class:`.Key` (:pull:`98`).
+
+  - New method :meth:`.Key.rename`.
+  - Key supports the Python operations :py:`+` (= :meth:`.add_tag`), :py:`*` (= :meth:`.append` a dimension), :py:`/` (= :meth:`.drop` a dimension).
+
 - Add :func:`.computations.sub` (:pull:`97``).
 - Provide typed signatures for :meth:`.Quantity.astype`, :attr:`~.Quantity.data`, and :meth:`~.Quantity.pipe`, and :meth:`~.Quantity.__neg__` for the benefit of downstream applications (:pull:`97`).
 - :func:`~.genno.computations.concat` handles N-dimensional quantities with dimensions in any order (:issue:`38`, :pull:`97`).

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,20 @@ What's new
 Next release
 ============
 
+This release adjusts the documentation by using language more carefully and precisely in line with :mod:`.dask` (:issue:`34`):
+
+- A **computation** is *any* entry in the :attr:`.Computer.graph`: even a simple alias, or a list of other keys with no specific operation to be performed.
+- A **task** is a specific kind of computation: a tuple that consists of a callable first item (usually a function) and other items—including keys and literal values—that are arguments to that callable.
+- An **operator** is a function or callable that is used as the first item in a task.
+  The new :class:`.Operator` class is named to align with this meaning.
+
+To complete this shift, in future releases of :mod:`.genno`:
+
+1. The module :mod:`.genno.computations` will be renamed to :mod:`.genno.operators`.
+   At this point, imports from :mod:`.genno.computations` will continue to function, but will trigger a :class:`.DeprecationWarning`.
+2. :mod:`.genno.computations` will be removed entirely.
+   This will happen no sooner than 6 months after (1), and with at least 1 minor version in between.
+
 Migration notes
 ---------------
 
@@ -24,13 +38,15 @@ All changes
   This class allows to combine a function/callable for use in computations with an optional :meth:`~.Operator.helper` convenience method for adding tasks to a :class:`.Computer`.
   :meth:`.Computer.add` calls these helpers automatically, if they exist.
 - New method :meth:`.Computer.eval` for using Python code-like expressions to define tasks and keys (:pull:`97`).
-- Deprecate methods: :meth:`.Computer.add_file`, :meth:`.Computer.add_product`, :meth:`.Computer.convert_pyam`, and :meth:`.Computer.disaggregate` (:pull:`98`).
 - Add :meth:`.Key.rename` (:pull:`98`).
-- Provide typed signatures for :meth:`.Quantity.astype`, :attr:`~.Quantity.data`, and :meth:`~.Quantity.pipe`, and :meth:`~.Quantity.__neg__` for the benefit of downstream applications (:pull:`97`).
 - Add :func:`.computations.sub` (:pull:`97``).
+- Provide typed signatures for :meth:`.Quantity.astype`, :attr:`~.Quantity.data`, and :meth:`~.Quantity.pipe`, and :meth:`~.Quantity.__neg__` for the benefit of downstream applications (:pull:`97`).
 - :func:`~.genno.computations.concat` handles N-dimensional quantities with dimensions in any order (:issue:`38`, :pull:`97`).
 - :func:`~.computations.pow` will derive units if the exponent is a Quantity with all identical integer values (:pull:`97`).
-- Deprecate :meth:`.Plot.make_task`; the Plot class now has a :meth:`~.Plot.add_tasks` method, analogous to :meth:`~.Operator.add_tasks`, and so a Plot subclass can be provided directly to :meth:`.Computer.add` (:pull:`98`).
+- Deprecations:
+
+  - :meth:`.Computer.add_file`, :meth:`~.Computer.add_product`, :meth:`~.Computer.convert_pyam`, and :meth:`~.Computer.disaggregate` (:pull:`98`).
+  - :meth:`.Plot.make_task`; the Plot class now has a :meth:`~.Plot.add_tasks` method, analogous to :meth:`~.Operator.add_tasks`, and so a Plot subclass can be provided directly to :meth:`.Computer.add` (:pull:`98`).
 
 v1.17.2 (2023-07-11)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,11 +4,33 @@ What's new
 Next release
 ============
 
+Migration notes
+---------------
+
+Code that uses the deprecated :class:`.Computer` convenience methods can be adjusted to use the corresponding :meth:`~.Operator.add_tasks` helpers—which give equivalent behaviour—via :meth:`.Computer.add`.
+See the documentation of the deprecated methods and/or warnings at runtime for examples and hints.
+
+- :meth:`.Computer.add_file` → use :func:`~.computations.load_file` and its helper.
+- :meth:`.Computer.add_product` → use :func:`~.computations.mul` and its helper.
+- :meth:`.Computer.convert_pyam` → use :func:`~.computations.as_pyam` and its helper.
+- :meth:`.Computer.disaggregate` and :func:`~.computations.disaggregate_shares`: use :func:`~.computations.mul` and its helper.
+
+For :meth:`.Plot.make_task` similarly change, for instance, :py:`c.add("plot", DemoPlot.make_task("x:t", "y:t"))` to :py:`c.add("plot", DemoPlot, "x:t", "y:t")`.
+
+All changes
+-----------
+
+- New class :class:`.Operator` (:pull:`98`).
+  This class allows to combine a function/callable for use in computations with an optional :meth:`~.Operator.helper` convenience method for adding tasks to a :class:`.Computer`.
+  :meth:`.Computer.add` calls these helpers automatically, if they exist.
 - New method :meth:`.Computer.eval` for using Python code-like expressions to define tasks and keys (:pull:`97`).
-- Provide typed signatures for :meth:`Quantity.astype`, :attr:`~Quantity.data`, and :meth:`~Quantity.pipe`, and :meth:`~Quantity.__neg__` for the benefit of downstream applications (:pull:`97`).
+- Deprecate methods: :meth:`.Computer.add_file`, :meth:`.Computer.add_product`, :meth:`.Computer.convert_pyam`, and :meth:`.Computer.disaggregate` (:pull:`98`).
+- Add :meth:`.Key.rename` (:pull:`98`).
+- Provide typed signatures for :meth:`.Quantity.astype`, :attr:`~.Quantity.data`, and :meth:`~.Quantity.pipe`, and :meth:`~.Quantity.__neg__` for the benefit of downstream applications (:pull:`97`).
 - Add :func:`.computations.sub` (:pull:`97``).
 - :func:`~.genno.computations.concat` handles N-dimensional quantities with dimensions in any order (:issue:`38`, :pull:`97`).
 - :func:`~.computations.pow` will derive units if the exponent is a Quantity with all identical integer values (:pull:`97`).
+- Deprecate :meth:`.Plot.make_task`; the Plot class now has a :meth:`~.Plot.add_tasks` method, analogous to :meth:`~.Operator.add_tasks`, and so a Plot subclass can be provided directly to :meth:`.Computer.add` (:pull:`98`).
 
 v1.17.2 (2023-07-11)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -26,6 +26,7 @@ See the documentation of the deprecated methods and/or warnings at runtime for e
 
 - :meth:`.Computer.add_file` → use :func:`~.computations.load_file` and its helper.
 - :meth:`.Computer.add_product` → use :func:`~.computations.mul` and its helper.
+- :meth:`.Computer.aggregate` → use :func:`~.computations.aggregate` or :func:`~.computations.sum` and its helper.
 - :meth:`.Computer.convert_pyam` → use :func:`~.computations.as_pyam` and its helper.
 - :meth:`.Computer.disaggregate` and :func:`~.computations.disaggregate_shares`: use :func:`~.computations.mul` and its helper.
 
@@ -49,7 +50,7 @@ All changes
 - :func:`~.computations.pow` will derive units if the exponent is a Quantity with all identical integer values (:pull:`97`).
 - Deprecations:
 
-  - :meth:`.Computer.add_file`, :meth:`~.Computer.add_product`, :meth:`~.Computer.convert_pyam`, and :meth:`~.Computer.disaggregate` (:pull:`98`).
+  - :meth:`.Computer.add_file`, :meth:`~.Computer.add_product`, :meth:`~.Computer.aggregate`, :meth:`~.Computer.convert_pyam`, and :meth:`~.Computer.disaggregate` (:pull:`98`).
   - :meth:`.Plot.make_task`; the Plot class now has a :meth:`~.Plot.add_tasks` method, analogous to :meth:`~.Operator.add_tasks`, and so a Plot subclass can be provided directly to :meth:`.Computer.add` (:pull:`98`).
 
 v1.17.2 (2023-07-11)

--- a/genno/__init__.py
+++ b/genno/__init__.py
@@ -4,6 +4,7 @@ from .config import configure
 from .core.computer import Computer
 from .core.exceptions import ComputationError, KeyExistsError, MissingKeyError
 from .core.key import Key
+from .core.operator import Operator
 from .core.quantity import Quantity
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "Key",
     "KeyExistsError",
     "MissingKeyError",
+    "Operator",
     "Quantity",
     "configure",
     "quote",

--- a/genno/compat/plotnine/plot.py
+++ b/genno/compat/plotnine/plot.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Hashable, Sequence
+from warnings import warn
 
 import plotnine as p9
 
@@ -89,6 +90,13 @@ class Plot(ABC):
               Computer.
             - The third and following elements are the `inputs`.
         """
+        inputs_repr = ",".join(map(repr, inputs))
+        warn(
+            f"Plot.make_task(…). Use: Computer.add(…, {cls.__name__}"
+            + (", " if inputs_repr else "")
+            + f"{inputs_repr})",
+            DeprecationWarning,
+        )
         return tuple([cls().save, "config"] + (list(inputs) if inputs else cls.inputs))
 
     @classmethod

--- a/genno/compat/plotnine/plot.py
+++ b/genno/compat/plotnine/plot.py
@@ -1,10 +1,13 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Hashable, Sequence
+from typing import TYPE_CHECKING, Hashable, Sequence
 
 import plotnine as p9
 
 from genno.core.quantity import Quantity
+
+if TYPE_CHECKING:
+    from genno.core.computer import Computer
 
 log = logging.getLogger(__name__)
 
@@ -87,6 +90,13 @@ class Plot(ABC):
             - The third and following elements are the `inputs`.
         """
         return tuple([cls().save, "config"] + (list(inputs) if inputs else cls.inputs))
+
+    @classmethod
+    def add_tasks(cls, c: "Computer", key, *inputs, strict: bool = False):
+        _inputs = list(inputs if inputs else cls.inputs)
+        if strict:
+            _inputs = c.check_keys(*_inputs)
+        c.add_single(key, cls().save, "config", *_inputs)
 
     @abstractmethod
     def generate(self, *args, **kwargs):

--- a/genno/compat/plotnine/plot.py
+++ b/genno/compat/plotnine/plot.py
@@ -77,6 +77,10 @@ class Plot(ABC):
     def make_task(cls, *inputs):
         """Return a task :class:`tuple` to add to a Computer.
 
+        .. deprecated:: 1.18.0
+
+           Use :func:`add_tasks` instead.
+
         Parameters
         ----------
         inputs : sequence of :class:`.Key`, :class:`str`, or other hashable, optional
@@ -101,6 +105,10 @@ class Plot(ABC):
 
     @classmethod
     def add_tasks(cls, c: "Computer", key, *inputs, strict: bool = False):
+        """Add a task to `c` to generate and save the Plot.
+
+        Analogous to :meth:`.Operator.add_tasks`.
+        """
         _inputs = list(inputs if inputs else cls.inputs)
         if strict:
             _inputs = c.check_keys(*_inputs)

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -17,9 +17,14 @@ log = logging.getLogger(__name__)
 @handles("iamc")
 def iamc(c: Computer, info):
     """Handle one entry from the ``iamc:`` config section."""
-    if not HAS_PYAM:  # pragma: no cover
-        log.warning("Missing pyam; configuration section 'iamc:' ignored")
-        return
+    try:
+        c.require_compat("pyam")
+    except ModuleNotFoundError:
+        if not HAS_PYAM:  # pragma: no cover
+            log.warning("Missing pyam; configuration section 'iamc:' ignored")
+            return
+        else:
+            raise
 
     from . import util
 

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -7,9 +7,11 @@ else:
 
 import logging
 from functools import partial
+from typing import List
 
 from genno import Computer, Key
 from genno.config import handles
+from genno.core.key import single_key
 
 log = logging.getLogger(__name__)
 
@@ -32,19 +34,21 @@ def iamc(c: Computer, info):
     name = info.pop("variable")
 
     # Chain of keys produced: first entry is the key for the base quantity
-    keys = [Key(info.pop("base"))]
+    keys: List[Key] = [Key(info.pop("base"))]
 
     # Second entry is a simple rename
-    keys.append(c.add_single(Key(name, keys[0].dims, keys[0].tag), keys[0]))
+    keys.append(single_key(c.add_single(Key(name, keys[0].dims, keys[0].tag), keys[0])))
 
     # Optionally select a subset of data from the base quantity
     sel = info.get("select")
     if sel:
         keys.append(
-            c.add_single(
-                keys[-1].add_tag("sel"),
-                (c.get_comp("select"), keys[-1], sel),
-                strict=True,
+            single_key(
+                c.add_single(
+                    keys[-1].add_tag("sel"),
+                    (c.get_comp("select"), keys[-1], sel),
+                    strict=True,
+                )
             )
         )
 
@@ -56,13 +60,16 @@ def iamc(c: Computer, info):
     # Use the Computer method to add the coversion step
     # NB convert_pyam() returns a single key when applied to a single key
     keys.append(
-        c.convert_pyam(
-            keys[-1],
-            rename=info.pop("rename", {}),
-            collapse=partial(collapse_func, **collapse_info),
-            replace=info.pop("replace", {}),
-            drop=set(info.pop("drop", [])) & set(keys[-1].dims),
-            unit=info.pop("unit", None),
+        single_key(
+            c.add(
+                keys[-1],
+                "as_pyam",
+                rename=info.pop("rename", {}),
+                collapse=partial(collapse_func, **collapse_info),
+                replace=info.pop("replace", {}),
+                drop=set(info.pop("drop", [])) & set(keys[-1].dims),
+                unit=info.pop("unit", None),
+            )
         )
     )
 

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -21,8 +21,8 @@ def iamc(c: Computer, info):
     """Handle one entry from the ``iamc:`` config section."""
     try:
         c.require_compat("pyam")
-    except ModuleNotFoundError:
-        if not HAS_PYAM:  # pragma: no cover
+    except ModuleNotFoundError:  # pragma: no cover
+        if not HAS_PYAM:
             log.warning("Missing pyam; configuration section 'iamc:' ignored")
             return
         else:

--- a/genno/compat/pyam/computations.py
+++ b/genno/compat/pyam/computations.py
@@ -8,8 +8,8 @@ from warnings import warn
 import pyam
 
 import genno.computations
-from genno.core.computation import computation
 from genno.core.key import Key
+from genno.core.operator import Operator
 
 from . import util
 
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 __all__ = ["as_pyam", "concat", "write_report"]
 
 
-@computation
+@Operator.define
 def as_pyam(
     scenario,
     quantity,

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -737,8 +737,12 @@ def add_mul(func, c: "Computer", key, *quantities, **kwargs) -> Key:
     # Compute a key for the result
     # Parse the name and tag of the target
     key = Key(key)
+
     # New key with dimensions of the product
-    key = Key.product(key.name, *base_keys, tag=key.tag)
+    candidate = Key.product(key.name, *base_keys, tag=key.tag)
+    # Only use this if it has greater dimensionality than `key`
+    if set(candidate.dims) >= set(key.dims):
+        key = candidate
 
     # Add the basic product to the graph and index
     kwargs.setdefault("sums", True)

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -28,7 +28,7 @@ from xarray.core.types import InterpOptions
 from xarray.core.utils import either_dict_or_kwargs
 
 from genno.core.attrseries import AttrSeries
-from genno.core.key import Key, iter_keys
+from genno.core.key import Key, iter_keys, single_key
 from genno.core.operator import Operator
 from genno.core.quantity import (
     Quantity,

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -1,4 +1,4 @@
-"""Elementary computations for genno."""
+"""Elementary operators for genno."""
 # NB To avoid ambiguity, computations should not have default positional arguments.
 #    Define default values for the corresponding methods on the Computer class.
 import logging
@@ -569,6 +569,10 @@ def load_file(
         Units to apply to the loaded Quantity.
     name : str
         Name for the loaded Quantity.
+
+    See also
+    --------
+    add_load_file
     """
     # TODO optionally cache: if the same Computer is used repeatedly, then the file will
     #      be read each time; instead cache the contents in memory.
@@ -588,10 +592,11 @@ def load_file(
 
 @load_file.helper
 def add_load_file(func, c: "Computer", path, key=None, **kwargs):
-    """Add exogenous quantities from *path*.
+    """:meth:`.Computer.add` helper for :func:`.load_file`.
 
-    Computing the `key` or using it in other computations causes `path` to be loaded and
-    converted to :class:`.Quantity`.
+    Add a task to load an exogenous quantity from `path`. Computing the `key` or using
+    it in other computations causes `path` to be loaded and converted to
+    :class:`.Quantity`.
 
     Parameters
     ----------
@@ -611,12 +616,8 @@ def add_load_file(func, c: "Computer", path, key=None, **kwargs):
     Returns
     -------
     .Key
-        Either `key` (if given) or e.g. ``file:foo.ext`` based on the `path` name,
+        Either `key` (if given) or e.g. ``file foo.ext`` based on the `path` name,
         without directory components.
-
-    See also
-    --------
-    genno.computations.load_file
     """
     path = Path(path)
     key = key if key else "file {}".format(path.name)
@@ -699,7 +700,12 @@ def _load_file_csv(
 
 @Operator.define
 def mul(*quantities: Quantity) -> Quantity:
-    """Compute the product of any number of *quantities*."""
+    """Compute the product of any number of `quantities`.
+
+    See also
+    --------
+    add_mul
+    """
     result = reduce(operator.mul, quantities)
     result.units = reduce(operator.mul, collect_units(*quantities))
 
@@ -708,7 +714,9 @@ def mul(*quantities: Quantity) -> Quantity:
 
 @mul.helper
 def add_mul(func, c: "Computer", key, *quantities, **kwargs) -> Key:
-    """Add a computation that takes the product of `quantities`.
+    """:meth:`.Computer.add` helper for :func:`.mul`.
+
+    Add a computation that takes the product of `quantities`.
 
     Parameters
     ----------

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -699,11 +699,8 @@ def _load_file_csv(
 @Operator.define
 def mul(*quantities: Quantity) -> Quantity:
     """Compute the product of any number of *quantities*."""
-
     result = reduce(operator.mul, quantities)
-    u_result = reduce(operator.mul, collect_units(*quantities))
-
-    result.units = u_result
+    result.units = reduce(operator.mul, collect_units(*quantities))
 
     return result
 

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -709,7 +709,7 @@ def mul(*quantities: Quantity) -> Quantity:
 
 
 @mul.helper
-def add_mul(func, c: "Computer", key, *quantities, sums=True) -> Key:
+def add_mul(func, c: "Computer", key, *quantities, **kwargs) -> Key:
     """Add a computation that takes the product of `quantities`.
 
     Parameters
@@ -735,9 +735,10 @@ def add_mul(func, c: "Computer", key, *quantities, sums=True) -> Key:
     key = Key.product(key.name, *base_keys, tag=key.tag)
 
     # Add the basic product to the graph and index
-    keys = iter_keys(c.add(key, func, *base_keys, sums=sums))
+    kwargs.setdefault("sums", True)
+    keys = iter_keys(c.add(key, func, *base_keys, **kwargs))
 
-    return next(keys)
+    return next(keys) if kwargs["sums"] else single_key(keys)
 
 
 #: Alias of :func:`mul`, for backwards compatibility.

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -28,8 +28,8 @@ from xarray.core.types import InterpOptions
 from xarray.core.utils import either_dict_or_kwargs
 
 from genno.core.attrseries import AttrSeries
-from genno.core.computation import computation
 from genno.core.key import Key, iter_keys
+from genno.core.operator import Operator
 from genno.core.quantity import (
     Quantity,
     assert_quantity,
@@ -539,7 +539,7 @@ def interpolate(
     return qty.interp(coords, method, assume_sorted, kwargs, **coords_kwargs)
 
 
-@computation
+@Operator.define
 def load_file(
     path: Path,
     dims: Union[Collection[Hashable], Mapping[Hashable, Hashable]] = {},
@@ -696,7 +696,7 @@ def _load_file_csv(
     )
 
 
-@computation
+@Operator.define
 def mul(*quantities: Quantity) -> Quantity:
     """Compute the product of any number of *quantities*."""
 

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -415,10 +415,11 @@ def convert_units(qty: Quantity, units: UnitLike) -> Quantity:
 
 
 def disaggregate_shares(quantity: Quantity, shares: Quantity) -> Quantity:
-    """Disaggregate *quantity* by *shares*."""
-    result = quantity * shares
-    result.units = collect_units(quantity)[0]
-    return result
+    """Deprecated: Disaggregate `quantity` by `shares`.
+
+    This operator is identical to :func:`mul`; use :func:`mul` and its helper instead.
+    """
+    return mul(quantity, shares)
 
 
 def div(numerator: Union[Quantity, float], denominator: Quantity) -> Quantity:

--- a/genno/computations.py
+++ b/genno/computations.py
@@ -29,7 +29,7 @@ from xarray.core.utils import either_dict_or_kwargs
 
 from genno.core.attrseries import AttrSeries
 from genno.core.computation import computation
-from genno.core.key import Key
+from genno.core.key import Key, iter_keys
 from genno.core.quantity import (
     Quantity,
     assert_quantity,
@@ -726,7 +726,7 @@ def add_mul(func, c: "Computer", key, *quantities, sums=True) -> Key:
         The full key of the new quantity.
     """
     # Fetch the full key for each quantity
-    base_keys = list(map(Key, c.check_keys(*quantities) or []))
+    base_keys = c.check_keys(*quantities, predicate=lambda v: isinstance(v, Quantity))
 
     # Compute a key for the result
     # Parse the name and tag of the target
@@ -735,9 +735,9 @@ def add_mul(func, c: "Computer", key, *quantities, sums=True) -> Key:
     key = Key.product(key.name, *base_keys, tag=key.tag)
 
     # Add the basic product to the graph and index
-    keys = c.add(key, func, *base_keys, sums=sums)
+    keys = iter_keys(c.add(key, func, *base_keys, sums=sums))
 
-    return keys[0]
+    return next(keys)
 
 
 #: Alias of :func:`mul`, for backwards compatibility.

--- a/genno/config.py
+++ b/genno/config.py
@@ -166,14 +166,22 @@ def aggregate(c: Computer, info):
 
     for qty in quantities:
         try:
-            keys = c.aggregate(qty, tag, groups, sums=True, fail=fail)
+            result = c.add(
+                Key(qty).add_tag(tag),
+                "aggregate",
+                groups=groups,
+                strict=True,
+                sums=True,
+                fail=fail,
+            )
+
         except KeyExistsError:
             pass
         except MissingKeyError:
             if fail == "error":
                 raise
         else:
-            if len(keys):
+            if keys := list(iter_keys(result)):
                 log.info(f"Add {repr(keys[0])} + {len(keys)-1} partial sums")
 
 

--- a/genno/config.py
+++ b/genno/config.py
@@ -164,17 +164,17 @@ def aggregate(c: Computer, info):
     fail = info.pop("_fail", None)
     groups = {info.pop("_dim"): info}
 
-    for qty in quantities:
+    for qty in map(Key, quantities):
         try:
             result = c.add(
-                Key(qty).add_tag(tag),
+                qty.add_tag(tag),
                 "aggregate",
+                qty,
                 groups=groups,
                 strict=True,
                 sums=True,
                 fail=fail,
             )
-
         except KeyExistsError:
             pass
         except MissingKeyError:

--- a/genno/config.py
+++ b/genno/config.py
@@ -34,16 +34,16 @@ STORE = set(["cache_path", "cache_skip"])
 
 
 def configure(path: Optional[Union[Path, str]] = None, **config):
-    """Configure :mod:`genno` globally.
+    """Configure :mod:`.genno` globally.
 
     Modifies global variables that affect the behaviour of *all* Computers and
-    computations. Configuration keys loaded from file are superseded by keyword
-    arguments. Messages are logged at level :obj:`logging.INFO` if `config` contains
-    unhandled sections.
+    operators. Configuration keys loaded from file are superseded by keyword arguments.
+    Messages are logged at level :obj:`logging.INFO` if `config` contains unhandled
+    sections.
 
     Parameters
     ----------
-    path : Path, optional
+    path : pathlib.Path, optional
         Path to a configuration file in JSON or YAML format.
     **config :
         Configuration keys/sections and values.

--- a/genno/core/computation.py
+++ b/genno/core/computation.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Tuple, Union
 
 if TYPE_CHECKING:
     from .computer import Computer
+    from .key import KeyLike
 
 
 class Computation:
@@ -26,7 +27,9 @@ class Computation:
         """Register `func` as the convenience method for adding task(s)."""
         self._add_tasks = func
 
-    def add_tasks(self, c: "Computer", *args, **kwargs):
+    def add_tasks(
+        self, c: "Computer", *args, **kwargs
+    ) -> Union["KeyLike", Tuple["KeyLike", ...]]:
         """Invoke :attr:`_add_task` to add (a) task(s) to `c`."""
         if self._add_tasks is None:
             raise NotImplementedError

--- a/genno/core/computation.py
+++ b/genno/core/computation.py
@@ -23,7 +23,7 @@ class Computation:
     def __repr__(self):
         return f"<{self.__class__.__name__}>"
 
-    def helper(self, func: Callable) -> None:
+    def helper(self, func: Callable[..., Tuple["KeyLike", ...]]) -> None:
         """Register `func` as the convenience method for adding task(s)."""
         self._add_tasks = func
 

--- a/genno/core/computation.py
+++ b/genno/core/computation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Tuple
 
 if TYPE_CHECKING:
     from .computer import Computer
@@ -27,9 +27,7 @@ class Computation:
         """Register `func` as the convenience method for adding task(s)."""
         self._add_tasks = func
 
-    def add_tasks(
-        self, c: "Computer", *args, **kwargs
-    ) -> Union["KeyLike", Tuple["KeyLike", ...]]:
+    def add_tasks(self, c: "Computer", *args, **kwargs) -> Tuple["KeyLike", ...]:
         """Invoke :attr:`_add_task` to add (a) task(s) to `c`."""
         if self._add_tasks is None:
             raise NotImplementedError

--- a/genno/core/computation.py
+++ b/genno/core/computation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Tuple
 
 if TYPE_CHECKING:
     from .computer import Computer
@@ -11,10 +11,10 @@ class Computation:
     # Use these specific attribute names to be intelligible to functools.partial()
     __slots__ = "func", "args", "keywords", "_add_tasks"
 
-    def __init__(self, func):
+    def __init__(self, func: Callable):
         self.func = func
         self.args = ()
-        self.kwargs = {}
+        self.keywords: Dict[str, Any] = {}
 
     def __call__(self, *args, **kwargs):
         # Don't pass `self` to the callable
@@ -32,7 +32,7 @@ class Computation:
         if self._add_tasks is None:
             raise NotImplementedError
 
-        return self._add_tasks(self, c, *args, **kwargs)
+        return self._add_tasks(self.func, c, *args, **kwargs)
 
 
 def computation(func: Callable):

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -163,7 +163,7 @@ class Computer:
         return None
 
     def require_compat(self, pkg: Union[str, ModuleType]):
-        """Register computations from :mod:`genno.compat`/others for :func:`.get_comp`.
+        """Register computations from :mod:`genno.compat`/others for :meth:`.get_comp`.
 
         The specified module is appended to :attr:`modules`.
 
@@ -228,7 +228,7 @@ class Computer:
 
         Returns
         -------
-        Key-like or tuple of Key-like
+        KeyLike or tuple of KeyLike
             Some or all of the keys added to the Computer.
 
         See also
@@ -236,8 +236,8 @@ class Computer:
         add_single
         add_queue
         apply
-        iter_keys
-        single_key
+        .iter_keys
+        .single_key
         """
         # Other methods
         if isinstance(data, Sequence) and not isinstance(data, str):
@@ -476,9 +476,9 @@ class Computer:
 
         Parameters
         ----------
-        generator : callable
+        generator : .callable
             Function to apply to `keys`.
-        keys : hashable
+        keys : Hashable
             The starting key(s).
         kwargs
             Keyword arguments to `generator`.
@@ -517,8 +517,8 @@ class Computer:
         - References to existing keys in the Computer by their name; these are expanded
           using :meth:`full_key`.
         - Multiple statements on separate lines or separated by ";".
-        - Python arithmetic operators including ``+``, ``*``, ``/``, ``**``; these are
-          mapped to the corresponding :mod:`.computations`.
+        - Python arithmetic operators including ``+``, ``-``, ``*``, ``/``, ``**``;
+          these are mapped to the corresponding :mod:`.computations`.
         - Function calls, also mapped to the corresponding :mod:`.computations` via
           :meth:`get_comp`. These may include simple positional (constants or key
           references) or keyword (constants only) arguments.
@@ -643,10 +643,10 @@ class Computer:
 
             1. ``k`` itself, unchanged, if `predicate` is given and ``predicate(k)``
                returns :obj:`True`.
-            2. :meth:`Graph.unsorted_key`, that is, ``k`` but with its dimensions in a
+            2. :meth:`.Graph.unsorted_key`, that is, ``k`` but with its dimensions in a
                specific order that already appears in :attr:`graph`.
-            3. :meth:`Graph.full_key`, that is, an existing key with the name ``k`` with
-               its full dimensionality.
+            3. :meth:`.Graph.full_key`, that is, an existing key with the name ``k``
+               with its full dimensionality.
             4. :obj:`None` otherwise.
 
         Raises

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -222,19 +222,13 @@ class Computer:
             # A list. Use add_queue to add
             return self.add_queue(data, *args, **kwargs)
 
-        elif isinstance(data, str) and self.get_comp(data):
+        elif func := self.get_comp(data):
             # *data* is the name of a pre-defined computation
-            name = data
-
-            if hasattr(self, f"add_{name}"):
-                # Use a method on the current class to add. This invokes any
-                # argument-handling conveniences, e.g. Computer.add_product()
-                # instead of using the bare product() computation directly.
-                return getattr(self, f"add_{name}")(*args, **kwargs)
-            else:
-                # Get the function directly
-                func = self.get_comp(name)
-                # Rearrange arguments: key, computation function, args, …
+            try:
+                # Use an implementation of Computation.add_task()
+                return func.add_tasks(*args, **kwargs)
+            except (AttributeError, NotImplementedError):
+                # No implementation; add manually
                 func, kwargs = partial_split(func, kwargs)
                 return self.add(args[0], func, *args[1:], **kwargs)
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -483,6 +483,9 @@ class Computer:
             # Update the graph with the computations
             self.graph.update(applied)
 
+        # FIXME capture and return the added keys
+        return ()
+
     def eval(self, expr: str) -> Tuple[Key, ...]:
         r"""Evaluate `expr` to add tasks and keys.
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -847,7 +847,15 @@ class Computer:
     # Deprecated methods
 
     def add_file(self, *args, **kwargs):
-        """Deprecated. Use ``Computer.add(…, "load_file" …) instead."""
+        """Deprecated.
+
+        .. deprecated:: 1.18.0
+           Instead use :func:`.add_load_file` via:
+
+           .. code-block:: python
+
+              c.add(..., "load_file", ...)
+        """
         arg = (args[1:2] if len(args) else None) or None
         warn(
             f"Computer.add_file(…). Use: Computer.add({kwargs.get('key', arg)!r}, "
@@ -858,7 +866,15 @@ class Computer:
         return computations.load_file.add_tasks(self, *args, **kwargs)
 
     def add_product(self, *args, **kwargs):
-        """Deprecated. Use ``Computer.add(…, "mul" …) instead."""
+        """Deprecated.
+
+        .. deprecated:: 1.18.0
+           Instead use :func:`.add_mul` via:
+
+           .. code-block:: python
+
+              c.add(..., "mul", ...)
+        """
         warn(
             f'Computer.add_product(…). Use: Computer.add({args[0]!r}, "mul", …)',
             DeprecationWarning,
@@ -867,14 +883,16 @@ class Computer:
         return computations.mul.add_tasks(self, *args, **kwargs)
 
     def convert_pyam(self, *args, **kwargs):
-        """Deprecated. Instead, use:
+        """Deprecated.
 
-        .. code-block:: python
+        .. deprecated:: 1.18.0
 
-           c = Computer()
-           c.require_compat("pyam")
-           c.add(…, "as_pyam", …)
+           Instead use :func:`.add_as_pyam` via:
 
+           .. code-block:: python
+
+              c.require_compat("pyam")
+              c.add(..., "as_pyam", ...)
         """
         warn(
             f"""Computer.convert_pyam(…). Use:
@@ -887,21 +905,22 @@ class Computer:
         return self.get_comp("as_pyam").add_tasks(self, *args, **kwargs)
 
     def disaggregate(self, qty, new_dim, method="shares", args=[]):
-        """Deprecated. Instead use one of:
+        """Deprecated.
 
-        For `method` = "disaggregate_shares":
+        .. deprecated:: 1.18.0
 
-        .. code-block:: python
+           Instead, for `method` = "disaggregate_shares", use:
 
-           c = Computer()
-           c.add(qty.append(new_dim), "mul", qty, …)
+           .. code-block:: python
 
-        For a :class:`callable` `method`:
+              c = Computer()
+              c.add(qty.append(new_dim), "mul", qty, ..., strict=True)
 
-        .. code-block:: python
+           Or for a :func:`callable` `method`, use:
 
-           c.add(qty.append(new_dim), method, qty, …)
+           .. code-block:: python
 
+              c.add(qty.append(new_dim), method, qty, ..., strict=True)
         """
         # Compute the new key
         key = Key(qty).append(new_dim)

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -841,10 +841,12 @@ class Computer:
     # Deprecated methods
 
     def add_file(self, *args, **kwargs):
+        arg = (args[1:2] if len(args) else None) or None
         warn(
-            "Computer.add_file(…). Use: Computer.add("
-            f'{kwargs.get("key") or args[1] if len(args) else "…"!r}, "load_file", …)',
+            f"Computer.add_file(…). Use: Computer.add({kwargs.get('key', arg)!r}, "
+            '"load_file", …)',
             DeprecationWarning,
+            stacklevel=-1,
         )
         return computations.load_file.add_tasks(self, *args, **kwargs)
 
@@ -852,6 +854,7 @@ class Computer:
         warn(
             f'Computer.add_product(…). Use: Computer.add({args[0]!r}, "mul", …)',
             DeprecationWarning,
+            stacklevel=-1,
         )
         return computations.mul.add_tasks(self, *args, **kwargs)
 
@@ -861,6 +864,7 @@ class Computer:
     Computer.require_compat("pyam")
     Computer.add({args[0]!r}, "as_pyam", …)""",
             DeprecationWarning,
+            stacklevel=-1,
         )
         self.require_compat("pyam")
         return self.get_comp("as_pyam").add_tasks(self, *args, **kwargs)

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -229,7 +229,7 @@ class Computer:
 
         Returns
         -------
-        list of Key-like
+        Key-like or tuple of Key-like
             Some or all of the keys added to the Computer.
 
         See also
@@ -237,6 +237,8 @@ class Computer:
         add_single
         add_queue
         apply
+        iter_keys
+        single_key
         """
         if isinstance(data, list):
             # A list. Use add_queue to add

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -719,21 +719,23 @@ class Computer:
                 raise NotImplementedError("aggregate() along >1 dimension")
 
             key = Key(qty).add_tag(tag)
-            comp: Tuple[Any, ...] = (
+            args: Tuple[Any, ...] = (
                 computations.aggregate,
                 qty,
                 dask.core.quote(groups),
                 keep,
             )
+            kwargs = dict()
         else:
             dims = dims_or_groups
             if isinstance(dims, str):
                 dims = [dims]
 
             key = Key(qty).drop(*dims).add_tag(tag)
-            comp = (partial(computations.sum, dimensions=dims), qty, weights)
+            args = ("sum", qty, weights)
+            kwargs = dict(dimensions=dims)
 
-        return self.add(key, comp, strict=True, sums=sums, fail=fail)
+        return self.add(key, *args, **kwargs, strict=True, sums=sums, fail=fail)
 
     add_aggregate = aggregate
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -239,26 +239,19 @@ class Computer:
         elif isinstance(data, (str, Key)):
             # *data* is a key, *args* are the computation
             key, computation = data, args
+            sums = kwargs.pop("sums", False)
+            fail = kwargs.pop("fail", "fail")
 
-            if kwargs.pop("sums", False):
-                # Convert *key* to a Key object in order to use .iter_sums()
-                key = Key(key)
+            # Add a single computation (without converting to Key)
+            result = self.add_single(key, *computation, **kwargs)
 
-                # Iterable of computations
-                # print((tuple([key] + list(computation)), kwargs))
-                # print([(c, {}) for c in key.iter_sums()])
-                to_add = chain(
-                    # The original
-                    [(tuple([key] + list(computation)), kwargs)],
-                    # One entry for each sum
-                    [(c, {}) for c in key.iter_sums()],
-                )
-
-                return self.add_queue(to_add, fail=kwargs.get("fail"))
+            if sums:
+                # Ensure `key`` is a Key object in order to use .iter_sums(); add one
+                # entry for each sum
+                return (result,) + self.add_queue(Key(key).iter_sums(), fail=fail)
             else:
-                # Add a single computation (without converting to Key)
-                kwargs.pop("fail", None)
-                return self.add_single(key, *computation, **kwargs)
+                return result
+
         else:
             # Some other kind of input
             raise TypeError(f"{type(data)} `data` argument")

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -442,19 +442,12 @@ class Computer:
             # Something else, such as pd.DataFrame or a literal
             return computation
 
-        # True if the element is key-like
-        is_keylike = list(map(lambda e: isinstance(e, (str, Key)), computation))
-
-        # Run only the key-like elements through check_keys(); make an iterator
-        checked = iter(self.check_keys(*compress(computation, is_keylike)))
-
         # Assemble the result using either checked keys (with properly ordered
         # dimensions) or unmodified elements from `computation`; cast to the same type
         return type(computation)(
-            [
-                next(checked) if is_keylike[i] else elem
-                for i, elem in enumerate(computation)
-            ]
+            self.check_keys(
+                *computation, predicate=lambda e: not isinstance(e, (Key, str))
+            )
         )
 
     def apply(self, generator, *keys, **kwargs):

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -395,7 +395,7 @@ class Computer:
             If `strict` is :obj:`True` and any key referred to by `computation` does
             not exist.
         """
-        if len(computation) == 1:
+        if len(computation) == 1 and not callable(computation[0]):
             # Unpack a length-1 tuple
             computation = computation[0]
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -674,12 +674,14 @@ class Computer:
         # Process all keys to produce more useful error messages
         result = list(map(_check, keys))
 
-        if action == "raise" and any(i is None for i in result):
-            # 1 or more keys missing
-            # Identify values in `keys` corresponding to None in `result`
-            raise MissingKeyError(
+        if action == "raise":
+            # Construct an exception with only (non-None) `keys` that correspond to None
+            # in `result`
+            exc = MissingKeyError(
                 *filter(None, compress(keys, map(lambda r: r is None, result)))
             )
+            if len(exc.args):  # 1 or more keys missing
+                raise exc
 
         return result
 

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -847,6 +847,7 @@ class Computer:
     # Deprecated methods
 
     def add_file(self, *args, **kwargs):
+        """Deprecated. Use ``Computer.add(…, "load_file" …) instead."""
         arg = (args[1:2] if len(args) else None) or None
         warn(
             f"Computer.add_file(…). Use: Computer.add({kwargs.get('key', arg)!r}, "
@@ -857,6 +858,7 @@ class Computer:
         return computations.load_file.add_tasks(self, *args, **kwargs)
 
     def add_product(self, *args, **kwargs):
+        """Deprecated. Use ``Computer.add(…, "mul" …) instead."""
         warn(
             f'Computer.add_product(…). Use: Computer.add({args[0]!r}, "mul", …)',
             DeprecationWarning,
@@ -865,6 +867,15 @@ class Computer:
         return computations.mul.add_tasks(self, *args, **kwargs)
 
     def convert_pyam(self, *args, **kwargs):
+        """Deprecated. Instead, use:
+
+        .. code-block:: python
+
+           c = Computer()
+           c.require_compat("pyam")
+           c.add(…, "as_pyam", …)
+
+        """
         warn(
             f"""Computer.convert_pyam(…). Use:
     Computer.require_compat("pyam")

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -220,7 +220,7 @@ class Computer:
 
     # Add computations to the Computer
 
-    def add(self, data, *args, **kwargs):
+    def add(self, data, *args, **kwargs) -> Union[KeyLike, Tuple[KeyLike, ...]]:
         """General-purpose method to add computations.
 
         :meth:`add` can be called in several ways; its behaviour depends on `data`; see
@@ -376,7 +376,9 @@ class Computer:
         return tuple(added)
 
     # Generic graph manipulations
-    def add_single(self, key, *computation, strict=False, index=False):
+    def add_single(
+        self, key: KeyLike, *computation, strict=False, index=False
+    ) -> KeyLike:
         """Add a single `computation` at `key`.
 
         Parameters

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -66,7 +66,7 @@ class Computer:
 
     # Action to take on failed items on add_queue(). This is a stack; the rightmost
     # element is current; the leftmost is the default.
-    _queue_fail: deque[int]
+    _queue_fail: MutableSequence[int]
 
     def __init__(self, **kwargs):
         self.graph = Graph(config=dict())

--- a/genno/core/describe.py
+++ b/genno/core/describe.py
@@ -109,7 +109,8 @@ def label(arg, max_length=MAX_ITEM_LENGTH) -> str:
                 ["..."],
             )
         )
-        return shorten(f"{arg.func.__name__}({fn_args})", max_length)
+        fn_repr = getattr(arg.func, "__name__", repr(arg.func))
+        return shorten(f"{fn_repr}({fn_args})", max_length)
     elif isinstance(arg, dask.core.literal):
         # Item protected with dask.core.quote()
         return shorten(str(arg.data), max_length)

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -86,6 +86,8 @@ class Key:
     def _(cls, value: Quantity):
         return str(value.name), tuple(map(str, value.dims)), None
 
+    # Class methods
+
     @classmethod
     def bare_name(cls, value) -> Optional[str]:
         """If `value` is a bare name (no dims or tags), return it; else :obj:`None`."""
@@ -173,6 +175,24 @@ class Key:
 
         # Return new key. Use dict to keep only unique *dims*, in same order
         return cls(new_name, dict.fromkeys(dims).keys()).add_tag(tag)
+
+    def __add__(self, other) -> "Key":
+        if isinstance(other, str):
+            return self.add_tag(other)
+        else:
+            raise TypeError(type(other))
+
+    def __mul__(self, other) -> "Key":
+        if isinstance(other, str):
+            return self.append(other)
+        else:
+            raise TypeError(type(other))
+
+    def __truediv__(self, other) -> "Key":
+        if isinstance(other, str):
+            return self.drop(other)
+        else:
+            raise TypeError(type(other))
 
     def __repr__(self) -> str:
         """Representation of the Key, e.g. '<name:dim1-dim2-dim3:tag>."""

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -303,15 +303,18 @@ def iter_keys(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Iterator[Key]:
     --------
     Computer.add
     """
-    if not isinstance(value, Iterable):
-        raise TypeError(type(value))
-    for element in value:
+    if isinstance(value, (Key, str)):
+        yield Key(value)
+        tmp: Iterator[KeyLike] = iter(())
+    else:
+        tmp = iter(value)
+    for element in tmp:
         if not isinstance(element, Key):
             raise TypeError(type(element))
         yield element
 
 
-def single_key(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Key:
+def single_key(value: Union[KeyLike, Tuple[KeyLike, ...], Iterator]) -> Key:
     """Ensure `value` is a single :class:`Key`.
 
     Raises
@@ -323,11 +326,23 @@ def single_key(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Key:
     --------
     Computer.add
     """
-    if isinstance(value, tuple):
-        assert 1 == len(value)
-        result = value[0]
+    if isinstance(value, (Key, str)):
+        return Key(value)
+
+    tmp = iter(value)
+    try:
+        result = next(tmp)
+    except StopIteration:
+        raise TypeError("Empty iterable")
     else:
-        result = value
-    if not isinstance(result, Key):
+        try:
+            next(tmp)
+        except StopIteration:
+            pass
+        else:
+            raise TypeError("Iterable of length >1")
+
+    if isinstance(result, Key):
+        return result
+    else:
         raise TypeError(type(result))
-    return result

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -238,7 +238,7 @@ class Key:
         """A version of the Key with its :attr:`dims` sorted alphabetically."""
         return Key(self._name, sorted(self._dims), self._tag, _fast=True)
 
-    def drop(self, *dims: Union[str, bool]):
+    def drop(self, *dims: Union[str, bool]) -> "Key":
         """Return a new Key with `dims` dropped."""
         return Key(
             self._name,
@@ -247,15 +247,15 @@ class Key:
             _fast=True,
         )
 
-    def drop_all(self):
+    def drop_all(self) -> "Key":
         """Return a new Key with all dimensions dropped / zero dimensions."""
         return Key(self._name, tuple(), self._tag, _fast=True)
 
-    def append(self, *dims: str):
+    def append(self, *dims: str) -> "Key":
         """Return a new Key with additional dimensions `dims`."""
         return Key(self._name, list(self._dims) + list(dims), self._tag, _fast=True)
 
-    def add_tag(self, tag):
+    def add_tag(self, tag) -> "Key":
         """Return a new Key with `tag` appended."""
         return Key(
             self._name, self._dims, "+".join(filter(None, [self._tag, tag])), _fast=True

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -2,7 +2,7 @@ import logging
 import re
 from functools import partial, singledispatchmethod
 from itertools import chain, compress
-from typing import Callable, Generator, Iterable, Optional, Tuple, Union
+from typing import Callable, Generator, Iterable, Iterator, Optional, Tuple, Union
 from warnings import warn
 
 from genno.core.quantity import Quantity
@@ -285,3 +285,45 @@ def combo_partition(iterable):
         # Two binary lists
         a, b = zip(*[(v, not v) for v in map(int, format(n, fmt))])
         yield list(compress(iterable, a)), list(compress(iterable, b))
+
+
+def iter_keys(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Iterator[Key]:
+    """Yield :class:`Keys <Key>` from `value`.
+
+    Raises
+    ------
+    TypeError
+        `value` is not an iterable of :class:`Key`.
+
+    See also
+    --------
+    Computer.add
+    """
+    if not isinstance(value, Iterable):
+        raise TypeError(type(value))
+    for element in value:
+        if not isinstance(element, Key):
+            raise TypeError(type(element))
+        yield element
+
+
+def single_key(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Key:
+    """Ensure `value` is a single :class:`Key`.
+
+    Raises
+    ------
+    TypeError
+        `value` is not a :class:`Key` or 1-tuple of :class:`Key`.
+
+    See also
+    --------
+    Computer.add
+    """
+    if isinstance(value, tuple):
+        assert 1 == len(value)
+        result = value[0]
+    else:
+        result = value
+    if not isinstance(result, Key):
+        raise TypeError(type(result))
+    return result

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -238,6 +238,10 @@ class Key:
         """A version of the Key with its :attr:`dims` sorted alphabetically."""
         return Key(self._name, sorted(self._dims), self._tag, _fast=True)
 
+    def rename(self, name: str) -> "Key":
+        """Return a Key with a replaced `name`."""
+        return Key(name, self._dims, self._tag, _fast=True)
+
     def drop(self, *dims: Union[str, bool]) -> "Key":
         """Return a new Key with `dims` dropped."""
         return Key(

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -301,7 +301,7 @@ def iter_keys(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Iterator[Key]:
 
     See also
     --------
-    Computer.add
+    .Computer.add
     """
     if isinstance(value, (Key, str)):
         yield Key(value)
@@ -324,7 +324,7 @@ def single_key(value: Union[KeyLike, Tuple[KeyLike, ...], Iterator]) -> Key:
 
     See also
     --------
-    Computer.add
+    .Computer.add
     """
     if isinstance(value, (Key, str)):
         return Key(value)

--- a/genno/core/operator.py
+++ b/genno/core/operator.py
@@ -1,6 +1,6 @@
 from functools import update_wrapper
 from inspect import signature
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from .computer import Computer
@@ -66,7 +66,9 @@ class Operator:
         #    will skip documenting items that have the same __doc__ as their class
         return update_wrapper(klass(), func, updated=())
 
-    def helper(self, func: Callable[..., Tuple["KeyLike", ...]]) -> Callable:
+    def helper(
+        self, func: Callable[..., Union["KeyLike", Tuple["KeyLike", ...]]]
+    ) -> Callable:
         """Register `func` as the convenience method for adding task(s)."""
         self.__class__._add_tasks = staticmethod(func)
         return func

--- a/genno/core/operator.py
+++ b/genno/core/operator.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from .key import KeyLike
 
 
-class Computation:
+class Operator:
     """Base class for a callable with convenience methods."""
 
     # Use these specific attribute names to be intelligible to functools.partial()
@@ -23,19 +23,19 @@ class Computation:
     def __repr__(self):
         return f"<{self.__class__.__name__}>"
 
+    @staticmethod
+    def define(func: Callable) -> "Operator":
+        """Create a :class:`Operator` object that wraps `func`."""
+        # Create a class and return an instance of it
+        return type(func.__name__, (Operator,), {})(func)
+
     def helper(self, func: Callable[..., Tuple["KeyLike", ...]]) -> None:
         """Register `func` as the convenience method for adding task(s)."""
         self._add_tasks = func
 
     def add_tasks(self, c: "Computer", *args, **kwargs) -> Tuple["KeyLike", ...]:
-        """Invoke :attr:`_add_task` to add (a) task(s) to `c`."""
+        """Invoke :attr:`_add_task` to add tasks to `c`."""
         if self._add_tasks is None:
             raise NotImplementedError
 
         return self._add_tasks(self.func, c, *args, **kwargs)
-
-
-def computation(func: Callable):
-    """Create a :class:`Computation` object that wraps `func`."""
-    # Create a class and return an instance of it
-    return type(func.__name__, (Computation,), {})(func)

--- a/genno/core/operator.py
+++ b/genno/core/operator.py
@@ -25,10 +25,13 @@ class Operator:
     """
 
     # Use these specific attribute names to be intelligible to functools.partial()
+    #: Function or callable for the Operator.
     func: ClassVar[Callable]
     args = ()
     keywords: Dict[str, Any] = dict()
 
+    #: Helper method to add tasks to a :class:`.Computer`. Register with :meth:`helper`,
+    #: invoke with :meth:`add_tasks`.
     _add_tasks: ClassVar[Optional[Callable]] = None
 
     def __call__(self, *args, **kwargs):
@@ -40,7 +43,7 @@ class Operator:
 
     @staticmethod
     def define(func: Callable) -> "Operator":
-        """Create a :class:`Operator` object that wraps `func`."""
+        """Create an Operator object that wraps `func`."""
         # This follows the pattern of using a metaclass, except compressed
 
         # - Create the class

--- a/genno/core/operator.py
+++ b/genno/core/operator.py
@@ -38,6 +38,10 @@ class Operator:
         # The callable is stored as a static method; `self` is not passed
         return self.func(*args, **kwargs)
 
+    def __eq__(self, other):
+        """Compares equal to the wrapped `func`."""
+        return other == self.func
+
     def __repr__(self):
         return f"<operator {self.__class__.__name__}>"
 

--- a/genno/testing/__init__.py
+++ b/genno/testing/__init__.py
@@ -289,13 +289,13 @@ def assert_qty_equal(
     Parameters
     ----------
     check_type : bool, optional
-        Assert that `a` and `b` are both :class:`Quantity` instances. If :obj:`False`,
+        Assert that `a` and `b` are both :class:`.Quantity` instances. If :obj:`False`,
         the arguments are converted to Quantity.
     check_attrs : bool, optional
         Also assert that check that attributes are identical.
     ignore_extra_coords : bool, optional
         Ignore extra coords that are not dimensions. Only meaningful when Quantity is
-        :class:`SparseDataArray`.
+        :class:`.SparseDataArray`.
     """
     __tracebackhide__ = True
 
@@ -345,13 +345,13 @@ def assert_qty_allclose(
     Parameters
     ----------
     check_type : bool, optional
-        Assert that `a` and `b` are both :class:`Quantity` instances. If :obj:`False`,
+        Assert that `a` and `b` are both :class:`.Quantity` instances. If :obj:`False`,
         the arguments are converted to Quantity.
     check_attrs : bool, optional
         Also assert that check that attributes are identical.
     ignore_extra_coords : bool, optional
         Ignore extra coords that are not dimensions. Only meaningful when Quantity is
-        :class:`SparseDataArray`.
+        :class:`.SparseDataArray`.
     """
     __tracebackhide__ = True
 

--- a/genno/tests/compat/test_plotnine.py
+++ b/genno/tests/compat/test_plotnine.py
@@ -143,7 +143,7 @@ def test_plot_none(caplog, tmp_path):
         def generate(self):
             return []
 
-    c.add("plot-1", Plot1.make_task())
+    c.add("plot-1", Plot1)
     # Returns None
     assert c.get("plot-1") is None
     # Message is logged
@@ -151,6 +151,6 @@ def test_plot_none(caplog, tmp_path):
 
     caplog.clear()
 
-    c.add("plot-2", Plot2.make_task())
+    c.add("plot-2", Plot2)
     assert c.get("plot-2") is None
     assert "Plot2.generate() returned []; no output" == caplog.messages[-1]

--- a/genno/tests/compat/test_plotnine.py
+++ b/genno/tests/compat/test_plotnine.py
@@ -10,6 +10,35 @@ from genno import Computer, MissingKeyError, Quantity
 from genno.compat.plotnine import Plot
 
 
+class Plot1(Plot):
+    inputs = ["x:t", "y:t"]
+
+
+class Plot2(Plot):
+    basename = "test"
+    suffix = ".svg"
+
+    def generate(self, x, y):
+        return p9.ggplot(x.merge(y, on="t"), p9.aes(x="x", y="y")) + p9.geom_point()
+
+
+class Plot3(Plot2):
+    """Concrete Plot subclasses can be further subclassed."""
+
+    suffix = ".pdf"
+    inputs = ["x:t", "y:t"]
+
+    def generate(self, x, y):
+        """Return an iterable of 2 plots."""
+        return (super().generate(x, y), super().generate(x, y))
+
+
+class Plot4(Plot3):
+    """Plot that requires a non-existent key as an input."""
+
+    inputs = ["x:t", "notakey"]
+
+
 def test_Plot(caplog, tmp_path):
     c = Computer(output_dir=tmp_path)
     t = [("t", [-1, 0, 1])]
@@ -17,8 +46,6 @@ def test_Plot(caplog, tmp_path):
     c.add("y:t", Quantity(xr.DataArray([1.0, 2, 3], coords=t), name="y"))
 
     # Exception raised when the class is incomplete
-    class Plot1(Plot):
-        inputs = ["x:t", "y:t"]
 
     with pytest.raises(
         TypeError,
@@ -27,16 +54,9 @@ def test_Plot(caplog, tmp_path):
             "Can't instantiate abstract class Plot1 with abstract methods? generate"
         ),
     ):
-        c.add("plot", Plot1.make_task())
+        c.add("plot", Plot1)
 
-    class Plot2(Plot):
-        basename = "test"
-        suffix = ".svg"
-
-        def generate(self, x, y):
-            return p9.ggplot(x.merge(y, on="t"), p9.aes(x="x", y="y")) + p9.geom_point()
-
-    c.add("plot", Plot2.make_task("x:t", "y:t"))
+    c.add("plot", Plot2, "x:t", "y:t")
 
     # Graph contains the task. Don't compare the callable
     assert ("config", "x:t", "y:t") == c.graph["plot"][1:]
@@ -49,28 +69,58 @@ def test_Plot(caplog, tmp_path):
     assert isinstance(result, Path)
 
     # Concrete Plot subclasses can be further subclassed
-    class Plot3(Plot2):
-        suffix = ".pdf"
-        inputs = ["x:t", "y:t"]
-
-        def generate(self, x, y):
-            # Return an iterable of 2 plots
-            return (super().generate(x, y), super().generate(x, y))
 
     # Multi-page PDFs can be saved
-    c.add("plot", Plot3.make_task())
+    c.add("plot", Plot3)
     c.get("plot")
-
-    # Plot that requires a non-existent key as input
-    class Plot4(Plot3):
-        inputs = ["x:t", "notakey"]
 
     # Raised during add(…, strict=True)
     with pytest.raises(MissingKeyError, match=re.escape("required keys ('notakey',)")):
+        c.add("plot4", Plot4, strict=True)
+
+    # Logged during get()
+    c.add("plot", Plot4)
+    c.get("plot")
+
+    assert "Missing input(s) ('notakey',) to plot 'test'; no output" in caplog.messages
+
+
+def test_Plot_deprecated(caplog, tmp_path):
+    """Same as above, but using deprecated Plot.make_task()."""
+    c = Computer(output_dir=tmp_path)
+    t = [("t", [-1, 0, 1])]
+    c.add("x:t", Quantity(xr.DataArray([1.0, 2, 3], coords=t), name="x"))
+    c.add("y:t", Quantity(xr.DataArray([1.0, 2, 3], coords=t), name="y"))
+
+    with pytest.warns(DeprecationWarning):
+        c.add("plot", Plot2.make_task("x:t", "y:t"))
+
+    # Graph contains the task. Don't compare the callable
+    assert ("config", "x:t", "y:t") == c.graph["plot"][1:]
+    assert callable(c.graph["plot"][0])
+
+    # Plot can be generated
+    result = c.get("plot")
+
+    # Result is the path to the file
+    assert isinstance(result, Path)
+
+    # Concrete Plot subclasses can be further subclassed
+
+    # Multi-page PDFs can be saved
+    with pytest.warns(DeprecationWarning):
+        c.add("plot", Plot3.make_task())
+    c.get("plot")
+
+    # Raised during add(…, strict=True)
+    with pytest.raises(
+        MissingKeyError, match=re.escape("required keys ('notakey',)")
+    ), pytest.warns(DeprecationWarning):
         c.add("plot4", Plot4.make_task(), strict=True)
 
     # Logged during get()
-    c.add("plot", Plot4.make_task())
+    with pytest.warns(DeprecationWarning):
+        c.add("plot", Plot4.make_task())
     c.get("plot")
 
     assert "Missing input(s) ('notakey',) to plot 'test'; no output" in caplog.messages

--- a/genno/tests/compat/test_pyam.py
+++ b/genno/tests/compat/test_pyam.py
@@ -218,8 +218,12 @@ def test_computer_as_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
     assert all(df5["unit"] == "centiUSD / case")
     assert_series_equal(df4["value"], df5["value"] / 100.0)
 
+    # Convert multiple quantities at once
+    keys = c.add("as_pyam", ["var_cost", "var_cost"], **kw)
+    assert ("var_cost::iamc", "var_cost::iamc") == keys
 
-def test_convert_pyam_deprecated():
+
+def test_deprecated_convert_pyam():
     """Test deprecated usage of `replace` parameter to as_pyam."""
     c = Computer()
 

--- a/genno/tests/compat/test_pyam.py
+++ b/genno/tests/compat/test_pyam.py
@@ -129,7 +129,10 @@ def test_convert_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
         return df.drop(["t", "m"], axis=1)
 
     # Use the convenience function to add the node
-    key2 = c.convert_pyam(ACT, rename=rename, collapse=add_tm)
+    with pytest.warns(DeprecationWarning):
+        key2 = c.convert_pyam(ACT, rename=rename, collapse=add_tm)
+
+    key2 = c.add(ACT, "as_pyam", rename=rename, collapse=add_tm)
 
     # Keys of added node(s) are returned
     assert ACT.name + "::iamc" == key2
@@ -180,9 +183,10 @@ def test_convert_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
 
     # Use a name map to replace variable names
     replacements = {re.escape("Activity|canning_plant|production"): "Foo"}
-    key3 = c.convert_pyam(
-        ACT, rename=rename, replace=dict(variable=replacements), collapse=add_tm
-    )
+    kw = dict(rename=rename, replace=dict(variable=replacements), collapse=add_tm)
+    with pytest.warns(DeprecationWarning):
+        key3 = c.convert_pyam(ACT, **kw)
+    key3 = c.add(ACT, "as_pyam", **kw)
     df3 = c.get(key3).as_pandas()
 
     # Values are the same; different names
@@ -193,7 +197,10 @@ def test_convert_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
 
     # Now convert variable cost
     cb = partial(add_tm, name="Variable cost")
-    key4 = c.convert_pyam("var_cost", rename=rename, collapse=cb)
+    kw = dict(rename=rename, collapse=cb)
+    with pytest.warns(DeprecationWarning):
+        key4 = c.convert_pyam("var_cost", **kw)
+    key4 = c.add("var_cost", "as_pyam", **kw)
     df4 = c.get(key4).as_pandas().drop(["model", "scenario"], axis=1)
 
     # Results have the expected units

--- a/genno/tests/compat/test_pyam.py
+++ b/genno/tests/compat/test_pyam.py
@@ -89,7 +89,7 @@ def test_as_pyam(dantzig_computer, scenario):
         computations.as_pyam(scenario, input)
 
 
-def test_convert_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
+def test_computer_as_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
     caplog.set_level(logging.INFO)
     c = dantzig_computer
 
@@ -207,9 +207,11 @@ def test_convert_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
     assert all(df4["unit"] == "USD / case")
 
     # Also change units
-    key5 = c.convert_pyam(
-        "var_cost", rename=rename, collapse=cb, unit="centiUSD / case"
-    )
+    kw = dict(rename=rename, collapse=cb, unit="centiUSD / case")
+    with pytest.warns(DeprecationWarning):
+        key5 = c.convert_pyam("var_cost", **kw)
+    key5 = c.add("var_cost", "as_pyam", **kw)
+
     df5 = c.get(key5).as_pandas().drop(["model", "scenario"], axis=1)
 
     # Results have the expected units
@@ -218,6 +220,7 @@ def test_convert_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
 
 
 def test_convert_pyam_deprecated():
+    """Test deprecated usage of `replace` parameter to as_pyam."""
     c = Computer()
 
     c.add("foo", None)

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -151,7 +151,7 @@ class TestComputer:
         c.add("a:t-y", "x:t-y", sums=False)
 
         def func(qty):
-            return type(qty)
+            pass  # pragma: no cover
 
         with pytest.warns(DeprecationWarning):
             k1 = c.disaggregate(Key(x).rename("x"), "z", method=func, args=["z_shares"])

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -38,6 +38,28 @@ class TestComputer:
     def c(self):
         return Computer()
 
+    def test_add_invalid0(self, c):
+        with pytest.raises(TypeError, match="At least 1 argument required"):
+            c.add("foo")
+
+    def test_deprecated_add_file(self, tmp_path, c):
+        # Path to a temporary file
+        p = tmp_path / "foo.csv"
+
+        p.write_text(
+            """# Comment
+         x,  y, value
+        x1, y1, 1.2
+        """
+        )
+
+        with pytest.warns(DeprecationWarning):
+            k1 = c.add_file(p, name="foo")
+        assert k1 == "file foo.csv"
+
+        result = c.get(k1)
+        assert ("x", "y") == result.dims
+
     def test_deprecated_disaggregate(self, c):
         *_, x = add_test_data(c)
         c.add("z_shares", "<share data>")

--- a/genno/tests/core/test_describe.py
+++ b/genno/tests/core/test_describe.py
@@ -1,9 +1,11 @@
 import re
+from operator import itemgetter
 
 import pandas as pd
 import pytest
 
 from genno import Computer, Quantity
+from genno.core.describe import label
 from genno.core.sparsedataarray import SparseDataArray
 
 
@@ -35,3 +37,8 @@ def test_describe_shorten():
 all"""  # noqa: 501
         == c.describe()
     )
+
+
+def test_label():
+    """:func:`label` handles unusual callables."""
+    assert "operator.itemgetter(0)" == label(itemgetter(0))

--- a/genno/tests/core/test_key.py
+++ b/genno/tests/core/test_key.py
@@ -1,6 +1,7 @@
 import pytest
 
 from genno import Key
+from genno.core.key import iter_keys, single_key
 
 
 def test_key():
@@ -133,3 +134,24 @@ def test_gt_lt():
 
     with pytest.raises(TypeError):
         assert k > 1.1
+
+
+def test_iter_keys():
+    # Non-iterable
+    with pytest.raises(TypeError):
+        next(iter_keys(1.2))
+
+    # Iterable containing non-keys
+    with pytest.raises(TypeError):
+        list(iter_keys([Key("a"), Key("b"), 1.2]))
+
+
+def test_single_key():
+    # Single key is unpacked
+    k = Key("a")
+    result = single_key((k,))
+    assert k is result
+
+    # Tuple containing 1 non-key
+    with pytest.raises(TypeError):
+        single_key((1.2,))

--- a/genno/tests/core/test_key.py
+++ b/genno/tests/core/test_key.py
@@ -117,6 +117,14 @@ class TestKey:
         # __truediv__: drop a dimension
         assert "x:a-c" == key / "b"
 
+        # Invalid
+        with pytest.raises(TypeError):
+            key + 1.1
+        with pytest.raises(TypeError):
+            key * 2.2
+        with pytest.raises(TypeError):
+            key / 3.3
+
 
 def test_sorted():
     k1 = Key("foo", "abc")
@@ -172,3 +180,11 @@ def test_single_key():
     # Tuple containing 1 non-key
     with pytest.raises(TypeError):
         single_key((1.2,))
+
+    # Tuple containing >1 Keys
+    with pytest.raises(TypeError):
+        single_key((k, k))
+
+    # Empty iterable
+    with pytest.raises(TypeError):
+        single_key([])

--- a/genno/tests/core/test_key.py
+++ b/genno/tests/core/test_key.py
@@ -100,6 +100,23 @@ class TestKey:
         key = Key("out:nl-t-yv-ya-m-nd-c-l-h-hd")
         assert "out:t-yv-ya-c-l" == key.drop("h", "hd", "m", "nd", "nl")
 
+    def test_operations(self):
+        key = Key("x:a-b-c")
+
+        # __add__: Add a tag
+        assert "x:a-b-c:foo" == key + "foo"
+        # Associative: (key + "foo") is another key that supports __add__
+        assert "x:a-b-c:foo+bar" == key + "foo" + "bar"
+
+        # __mul__: add a dimension
+        assert "x:a-b-c-d" == key * "d"
+
+        # Existing dimension → no change
+        assert key == key * "c"
+
+        # __truediv__: drop a dimension
+        assert "x:a-c" == key / "b"
+
 
 def test_sorted():
     k1 = Key("foo", "abc")

--- a/genno/tests/core/test_operator.py
+++ b/genno/tests/core/test_operator.py
@@ -1,0 +1,16 @@
+import pytest
+
+from genno import Computer, Operator
+
+
+def null():
+    pass  # pragma: no cover
+
+
+class TestOperator:
+    def test_add_tasks(self):
+        op = Operator.define(null)
+
+        c = Computer()
+        with pytest.raises(NotImplementedError):
+            op.add_tasks(c)

--- a/genno/tests/data/config-aggregate2.yaml
+++ b/genno/tests/data/config-aggregate2.yaml
@@ -1,0 +1,25 @@
+aggregate:
+- _quantities: [ "X::", "Y::", "Z::" ]
+  _tag: agg
+  _dim: a
+  _fail: warning
+
+  baz123: [baz1, baz2, baz3]
+  baz13: [baz1, baz3]
+
+# Triggers non-fatal KeyExistsError
+- _quantities: [ "X::", "Y::", "Z::" ]
+  _tag: agg
+  _dim: a
+
+  baz123: [baz1, baz2, baz3]
+  baz13: [baz1, baz3]
+
+# Triggers MissingKeyError
+- _quantities: [ "X::", "Y::", "Q::" ]
+  _tag: agg2
+  _dim: a
+  _fail: "error"
+
+  baz123: [baz1, baz2, baz3]
+  baz13: [baz1, baz3]

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -626,6 +626,9 @@ def test_relabel(data):
     for args in [
         ("test", computations.relabel, "x:t-y", args),
         ("test", partial(computations.relabel, **args), "x:t-y"),
+        ("test", "relabel", "x:t-y", args),
+        ("test", "relabel", "x:t-y", "labels"),
+        # Deprecated
         ("relabel", "test", "x:t-y", args),
         ("relabel", "test", "x:t-y", "labels"),
     ]:
@@ -661,6 +664,9 @@ def test_rename_dims(data):
     for args in [
         ("test", computations.rename_dims, "x:t-y", args),
         ("test", partial(computations.rename_dims, **args), "x:t-y"),
+        ("test", "rename_dims", "x:t-y", args),
+        ("test", "rename_dims", "x:t-y", "dim name map"),
+        # Deprecated
         ("rename_dims", "test", "x:t-y", args),
         ("rename_dims", "test", "x:t-y", "dim name map"),
     ]:
@@ -749,7 +755,7 @@ def test_select_bigmem():
     k = c.add("random indexers", random_indexers, keys[0])
 
     # Add a task to select some values
-    key = c.add("select", "test key", keys[0], k)
+    key = c.add("test key", "select", keys[0], k)
 
     if Quantity._get_class() is SparseDataArray:
         # ValueError: invalid dims: array size defined by dims is larger than the

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -497,7 +497,14 @@ def test_load_file(test_data_path, ureg, name, kwargs):
     assert "baz" == qty.name
 
 
-@pytest.mark.parametrize("func", [computations.mul, computations.product])
+@pytest.mark.parametrize(
+    "func",
+    (
+        computations.mul,
+        computations.product,  # Alias
+        computations.disaggregate_shares,  # Deprecated alias
+    ),
+)
 def test_mul0(func):
     A = Quantity(xr.DataArray([1.0, 2], coords=[("a", ["a0", "a1"])]))
     B = Quantity(xr.DataArray([3.0, 4], coords=[("b", ["b0", "b1"])]))

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -111,6 +111,10 @@ def test_aggregate(caplog, data, keep):
     ):
         result = computations.aggregate(x, dict(t=t_groups), keep)
 
+    # Two dimensions
+    result = computations.aggregate(x, {"t": t_groups, "y": {"2k": [2000, 2010]}}, keep)
+    assert "2k" in result.coords["y"]
+
 
 def test_apply_units(data, caplog):
     # Unpack

--- a/genno/tests/test_config.py
+++ b/genno/tests/test_config.py
@@ -4,7 +4,7 @@ from importlib import import_module
 
 import pytest
 
-from genno import Computer, Key, configure
+from genno import Computer, Key, MissingKeyError, configure
 from genno.compat.pyam import HAS_PYAM
 from genno.config import HANDLERS, handles
 
@@ -33,6 +33,9 @@ def test_handlers():
     [
         "config-aggregate0.yaml",
         "config-aggregate1.yaml",
+        pytest.param(
+            "config-aggregate2.yaml", marks=pytest.mark.xfail(raises=MissingKeyError)
+        ),
         "config-combine.yaml",
         "config-general0.yaml",
         pytest.param(

--- a/genno/tests/test_util.py
+++ b/genno/tests/test_util.py
@@ -108,6 +108,9 @@ def test_partial_split():
     _, extra = partial_split(func2, kwargs)
     assert {"baz"} == set(extra.keys())
 
+    with pytest.raises(TypeError):
+        partial_split(1.2, kwargs)
+
 
 @pytest.mark.parametrize(
     "value, exp",

--- a/genno/util.py
+++ b/genno/util.py
@@ -157,7 +157,7 @@ def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, MutableMap
         par_names: Mapping = signature(func).parameters
     except ValueError:
         # signature() raises for operator.itemgetter(…), built-ins, and similar
-        if not callable(func):
+        if not callable(func):  # pragma: no cover
             raise TypeError(type(func))
         par_names = {}
 

--- a/genno/util.py
+++ b/genno/util.py
@@ -1,7 +1,7 @@
 import logging
 from functools import partial
 from inspect import Parameter, signature
-from typing import Callable, Iterable, Mapping, Tuple, Type, Union
+from typing import Callable, Iterable, Mapping, MutableMapping, Tuple, Type, Union
 
 import pandas as pd
 import pint
@@ -147,13 +147,19 @@ def parse_units(data: Iterable, registry=None) -> pint.Unit:
         raise invalid(unit, e)
 
 
-def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, Mapping]:
+def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, MutableMapping]:
     """Forgiving version of :func:`functools.partial`.
 
     Returns a :class:`partial` object and leftover kwargs not applicable to `func`.
     """
     # Names of parameters to `func`
-    par_names = signature(func).parameters
+    try:
+        par_names: Mapping = signature(func).parameters
+    except ValueError:
+        if callable(func):  # operator.itemgetter(…) or similar
+            par_names = {}
+        else:
+            raise
 
     func_args, extra = {}, {}
     for name, value in kwargs.items():

--- a/genno/util.py
+++ b/genno/util.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #: - The '%' symbol cannot be supported by pint, because it is a Python operator; it is
 #:   replaced with “percent”.
 #:
-#: Additional values can be added with :meth:`configure`; see :ref:`config-units`.
+#: Additional values can be added with :func:`configure`; see :ref:`config-units`.
 REPLACE_UNITS = {
     "%": "percent",
 }

--- a/genno/util.py
+++ b/genno/util.py
@@ -156,10 +156,10 @@ def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, MutableMap
     try:
         par_names: Mapping = signature(func).parameters
     except ValueError:
-        if callable(func):  # operator.itemgetter(…) or similar
-            par_names = {}
-        else:
-            raise
+        # signature() raises for operator.itemgetter(…), built-ins, and similar
+        if not callable(func):
+            raise TypeError(type(func))
+        par_names = {}
 
     func_args, extra = {}, {}
     for name, value in kwargs.items():
@@ -172,7 +172,10 @@ def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, MutableMap
         else:
             extra[name] = value
 
-    return partial(func, **func_args), extra
+    if func_args:
+        return partial(func, **func_args), extra
+    else:
+        return func, extra  # Nothing to partial; return `func` as-is
 
 
 def unquote(value):


### PR DESCRIPTION
This class consolidates, with the callable/function itself, any conveniences, special handling, or logic related to adding to a Computer tasks that use the callable.

- Simplify Computer by deprecating several of these convenience functions.
- Improve Computer.add():
  - Close #86.
- Close #34 with extensive revision of the documentation.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
