### PR TITLE
Adjust for pandas 2.1

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -42,12 +42,13 @@ All changes
 - Improve :class:`.Key` (:pull:`98`).
 
   - New method :meth:`.Key.rename`.
-  - Key supports the Python operations :py:`+` (= :meth:`.add_tag`), :py:`*` (= :meth:`.append` a dimension), :py:`/` (= :meth:`.drop` a dimension).
+  - Key supports the Python operations :py:`+` (= :meth:`.add_tag`), :py:`*` (= :meth:`.append` a dimension), :py:`/` (= :meth:`~.Key.drop` a dimension).
 
 - Add :func:`.computations.sub` (:pull:`97``).
 - Provide typed signatures for :meth:`.Quantity.astype`, :attr:`~.Quantity.data`, and :meth:`~.Quantity.pipe`, and :meth:`~.Quantity.__neg__` for the benefit of downstream applications (:pull:`97`).
 - :func:`~.genno.computations.concat` handles N-dimensional quantities with dimensions in any order (:issue:`38`, :pull:`97`).
 - :func:`~.computations.pow` will derive units if the exponent is a Quantity with all identical integer values (:pull:`97`).
+- Adjust for pandas 2.1.0 to prevent :class:`RecursionError` that could occur using :meth:`.AttrSeries.sel` (:pull:`99`).
 - Deprecations:
 
   - :meth:`.Computer.add_file`, :meth:`~.Computer.add_product`, :meth:`~.Computer.aggregate`, :meth:`~.Computer.convert_pyam`, and :meth:`~.Computer.disaggregate` (:pull:`98`).

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -127,7 +127,7 @@ class AttrSeries(pd.Series, Quantity):
             else:
                 attrs.update()
 
-        data, name = Quantity._single_column_df(data, name)
+        data, name = Quantity._single_column_df(data, name, copy=kwargs.get("copy"))
 
         if data is None:
             kwargs["dtype"] = float

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -151,7 +151,9 @@ class AttrSeries(pd.Series, Quantity):
     __truediv__ = _binop("div")
 
     def __repr__(self):
-        return super().__repr__() + f", units: {self.units}"
+        return (
+            super().__repr__() + f", units: {self.attrs.get('_unit', 'dimensionless')}"
+        )
 
     @classmethod
     def from_series(cls, series, sparse=None):

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -127,7 +127,7 @@ class AttrSeries(pd.Series, Quantity):
             else:
                 attrs.update()
 
-        data, name = Quantity._single_column_df(data, name, copy=kwargs.get("copy"))
+        data, name = Quantity._single_column_df(data, name)
 
         if data is None:
             kwargs["dtype"] = float

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -186,7 +186,7 @@ class AttrSeries(pd.Series, Quantity):
         #      if needed use _maybe_groupby()
         return self._replace(
             self.unstack(dim)
-            .fillna(method="bfill", axis=1, limit=limit)
+            .bfill(axis=1, limit=limit)
             .stack()
             .reorder_levels(self.dims),
         )
@@ -271,7 +271,7 @@ class AttrSeries(pd.Series, Quantity):
         #      if needed use _maybe_groupby()
         return self._replace(
             self.unstack(dim)
-            .fillna(method="ffill", axis=1, limit=limit)
+            .ffill(axis=1, limit=limit)
             .stack()
             .reorder_levels(self.dims),
         )

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -82,7 +82,7 @@ class Quantity(DataArrayLike["Quantity"]):
         return cls
 
     @staticmethod
-    def _single_column_df(data, name):
+    def _single_column_df(data, name, *, copy=None):
         """Handle `data` and `name` arguments to Quantity constructors."""
         if isinstance(data, pd.DataFrame):
             if len(data.columns) != 1:
@@ -92,8 +92,15 @@ class Quantity(DataArrayLike["Quantity"]):
 
             # Unpack a single column; use its name if not overridden by `name`
             return data.iloc[:, 0], (name or data.columns[0])
-        elif isinstance(data, pd.Series) and not isinstance(data.index, pd.MultiIndex):
-            return data.set_axis(pd.MultiIndex.from_product([data.index])), name
+        elif (
+            isinstance(data, pd.Series)
+            and not isinstance(data.index, pd.MultiIndex)
+            and copy
+        ):
+            return (
+                data.set_axis(pd.MultiIndex.from_product([data.index]), copy=copy),
+                name,
+            )
         else:
             return data, name
 

--- a/genno/core/quantity.py
+++ b/genno/core/quantity.py
@@ -82,7 +82,7 @@ class Quantity(DataArrayLike["Quantity"]):
         return cls
 
     @staticmethod
-    def _single_column_df(data, name, *, copy=None):
+    def _single_column_df(data, name):
         """Handle `data` and `name` arguments to Quantity constructors."""
         if isinstance(data, pd.DataFrame):
             if len(data.columns) != 1:
@@ -92,15 +92,6 @@ class Quantity(DataArrayLike["Quantity"]):
 
             # Unpack a single column; use its name if not overridden by `name`
             return data.iloc[:, 0], (name or data.columns[0])
-        elif (
-            isinstance(data, pd.Series)
-            and not isinstance(data.index, pd.MultiIndex)
-            and copy
-        ):
-            return (
-                data.set_axis(pd.MultiIndex.from_product([data.index]), copy=copy),
-                name,
-            )
         else:
             return data, name
 

--- a/genno/tests/compat/test_pyam.py
+++ b/genno/tests/compat/test_pyam.py
@@ -14,6 +14,11 @@ from genno.computations import add, load_file
 # Skip this entire file if pyam is not installed
 pyam = pytest.importorskip("pyam", reason="pyam-iamc not installed")
 
+# Warning emitted by pandas ≥ 2.1.0 with pyam 1.9.0
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*unique with argument that is not.*:FutureWarning:pyam.core"
+)
+
 
 @pytest.fixture(scope="session")
 def scenario():

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -263,6 +263,7 @@ class TestQuantity:
         y_idx = xr.DataArray(["y4", "y2", "y0"], coords=newdim)
 
         # Select using the indexers
+        # NB with pandas 2.1, this triggers the RecursionError fixed in khaeru/genno#99
         assert_qty_equal(
             Quantity(xr.DataArray([9.0, 3.0, 5.0], coords=newdim), units="kg"),
             tri.sel(x=x_idx, y=y_idx),

--- a/genno/tests/test_computations.py
+++ b/genno/tests/test_computations.py
@@ -742,6 +742,7 @@ def test_select(data):
             [2000, 2010, 2020], dims="new_dim", coords={"new_dim": ["d1", "d2", "d3"]}
         ),
     }
+    # NB with pandas 2.1, this triggers the RecursionError fixed in khaeru/genno#99
     result_4 = computations.select(x, indexers)
     assert ("new_dim",) == result_4.dims
 


### PR DESCRIPTION
At iiasa/message-ix-models#117, some tests are failing with:

<details>
<summary> Traceback </summary>

```py
>       assert (
            expected == qty_out.sel(node_loc=node_loc, technology="coal_ppl", year=2022)
        ).all()

message_ix_models/tests/util/test_node.py:106: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../genno/genno/core/attrseries.py:455: in sel
    data = data.droplevel(list(to_drop & set(data.index.names)))
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/generic.py:898: in droplevel
    return self.set_axis(new_labels, axis=axis, copy=None)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/series.py:4962: in set_axis
    return super().set_axis(labels, axis=axis, copy=copy)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/generic.py:745: in set_axis
    return self._set_axis_nocheck(labels, axis, inplace=False, copy=copy)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/generic.py:756: in _set_axis_nocheck
    obj = self.copy(deep=copy and not using_copy_on_write())
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/generic.py:6685: in copy
    return self._constructor_from_mgr(data, axes=data.axes).__finalize__(
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/series.py:589: in _constructor_from_mgr
    return self._constructor(ser, copy=False)
../../genno/genno/core/attrseries.py:130: in __init__
    data, name = Quantity._single_column_df(data, name, copy=kwargs.get("copy"))
../../genno/genno/core/quantity.py:102: in _single_column_df
    data.set_axis(pd.MultiIndex.from_product([data.index]), copy=copy),
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/arrays/categorical.py:449: in __init__
    codes, categories = factorize(values, sort=True)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/algorithms.py:763: in factorize
    return values.factorize(sort=sort, use_na_sentinel=use_na_sentinel)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/base.py:1195: in factorize
    codes, uniques = algorithms.factorize(
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/algorithms.py:795: in factorize
    codes, uniques = factorize_array(
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/algorithms.py:592: in factorize_array
    hash_klass, values = _get_hashtable_algo(values)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/algorithms.py:273: in _get_hashtable_algo
    values = _ensure_data(values)
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/algorithms.py:150: in _ensure_data
    elif is_bool_dtype(values.dtype):
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/dtypes/common.py:1235: in is_bool_dtype
    if isinstance(arr_or_dtype, ABCIndex):
../../../.venv/3.11/lib/python3.11/site-packages/pandas/core/dtypes/generic.py:44: in _instancecheck
    return _check(inst) and not isinstance(inst, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

inst = dtype('int64')

    def _check(inst) -> bool:
>       return getattr(inst, attr, "_typ") in comp
E       RecursionError: maximum recursion depth exceeded while calling a Python object

```

</details>

This occurs with pandas 2.1 (released today) but not pandas < 2.1. Additionally, it ~is~ was not triggered by the genno test suite—but only because no workflow run had occurred with the 2.1.0 release.

### PR checklist
- [x] Add a test that reproduces the exception.
- [x] Checks all ✅
- ~Update documentation~ N/A, internals only.
- [x] Update doc/whatsnew.rst
