### PR TITLE
Mark test_computationerror_ipython as flaky

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -83,4 +83,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+
+    - name: Force recreation of pre-commit virtual environment for mypy
+      if: github.event_name == 'schedule'  # Comment this line to run on a PR
+      run: gh cache list -L 999 | cut -f2 | grep pre-commit | xargs -I{} gh cache delete "{}" || true
+      env: { GH_TOKEN: "${{ github.token }}" }
+
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -25,7 +25,8 @@ jobs:
         python:
         # llvmlite (thus numba, thus sparse) usually lags the latest Python
         # release. Only test SparseDataArray where possible.
-        # Earliest version supported by genno; matches xarray/setup.cfg
+        # Earliest version supported by genno = earliest Python that has not
+        # reached EOL
         - {version: "3.8", extras: ",sparse"}
         - {version: "3.9", extras: ",sparse"}
         - {version: "3.10", extras: ",sparse"}
@@ -38,7 +39,7 @@ jobs:
         # Compiling these on the job runner requires a more elaborate build
         # environment, currently out of scope for genno. Exclude these versions
         # from CI.
-        # - {version: "3.12.0-alpha.2", extras: ""}  # Development version
+        # - {version: "3.13.0-rc.1", extras: ""}  # Development version
 
       fail-fast: false
 
@@ -61,14 +62,15 @@ jobs:
         macos-skip-brew-update: true
 
     - name: Install the Python package and dependencies
-      run: pip install --upgrade --upgrade-strategy=eager .[docs,tests${{ matrix.python.extras }}]
+      run: pip install --upgrade --upgrade-strategy=eager .[tests${{ matrix.python.extras }}]
 
     - name: Run test suite using pytest
-      run: pytest genno --trace-config --color=yes --verbose --cov-report=xml --cov-report=term --numprocesses auto
-
-    - name: Test documentation build using Sphinx
-      if: startsWith(matrix.os, 'ubuntu')
-      run: make -C doc html
+      run: |
+        pytest genno \
+          --trace-config --color=yes --verbose \
+          --cov-report=xml --cov-report=term \
+          --numprocesses auto
+      shell: bash
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v3

--- a/genno/tests/core/test_exceptions.py
+++ b/genno/tests/core/test_exceptions.py
@@ -1,4 +1,7 @@
+import os
 import re
+
+import pytest
 
 from genno import ComputationError, Computer
 from genno.testing import assert_logs
@@ -48,6 +51,12 @@ TypeError: can only concatenate str \(not "float"\) to str.*"""
 )
 
 
+@pytest.mark.flaky(
+    reruns=5,
+    rerun_delay=2,
+    condition="GITHUB_ACTIONS" in os.environ,
+    reason="Flaky; fails occasionally on GitHub Actions runners",
+)
 def test_computationerror_ipython(test_data_path, tmp_path):
     # NB this requires nbformat >= 5.0, because the output kind "evalue" was
     #    different pre-5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ tests = [
   "nbclient",
   "pytest",
   "pytest-cov",
+  "pytest-rerunfailures",
   "pytest-xdist",
 ]
 sparse = ["sparse >= 0.12"]


### PR DESCRIPTION
This test fails sporadically with CellTimeoutError.

Add pytest-rerunfailures to [tests] optional dependencies.

Also:
- Replace a Sphinx build step in the "pytest" CI workflow with the ReadTheDocs automated PR build & associated check.
- Force a daily refresh of the cached environment for mypy via pre-commit.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A; test/CI changes only
- ~Update doc/whatsnew.rst~ N/A
