### PR TITLE
Ensure multi-indexed AttrSeries; adjust for pytest 8

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -47,11 +47,11 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python.version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python.version }}
         cache: pip
@@ -81,8 +81,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bugfix: genno 1.23.0 would return :class:`.AttrSeries` with :class:`pandas.Index` (instead of 1-D :class:`pandas.MultiIndex`) from :meth:`~.AttrSeries.squeeze` (:issue:`120`, :pull:`122`).
 
 v1.23.0 (2024-01-26)
 ====================

--- a/genno/tests/core/test_attrseries.py
+++ b/genno/tests/core/test_attrseries.py
@@ -94,6 +94,19 @@ class TestAttrSeries:
         foo.shift(a=1)
         foo.shift(b=1)
 
+    def test_squeeze(self, foo) -> None:
+        """:meth:`squeeze` results in MultiIndex.
+
+        https://github.com/khaeru/genno/issues/120
+        https://github.com/iiasa/message_ix/issues/788
+        """
+        # Squeeze the length-1 dimension "a"
+        result = foo.sel(a=["a1"]).squeeze()
+
+        # Result is 1-D but multi-indexed
+        assert 1 == len(result.dims)
+        assert isinstance(result.index, pd.MultiIndex)
+
     def test_sum(self, foo, bar):
         # AttrSeries can be summed across all dimensions
         result = foo.sum(dim=["a", "b"])

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -134,7 +134,7 @@ class TestComputer:
         agg3 = c.get(key3)
         assert set(agg3.coords["t"].values) == set(t_groups.keys())
 
-        with pytest.raises(NotImplementedError), pytest.warns(DeprecationWarning):
+        with pytest.raises(NotImplementedError):
             # Not yet supported; requires two separate operations
             c.aggregate("x:t-y", "agg3", {"t": t_groups, "y": [2000, 2010]})
 
@@ -173,11 +173,11 @@ class TestComputer:
             c.disaggregate(g, "j")
 
         # Invalid method argument
-        with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError):
             c.disaggregate("x:", "d", method="baz")
 
         # Invalid method argument
-        with pytest.raises(TypeError), pytest.warns(DeprecationWarning):
+        with pytest.raises(TypeError):
             c.disaggregate("x:", "d", method=None)
 
 

--- a/genno/tests/core/test_key.py
+++ b/genno/tests/core/test_key.py
@@ -2,6 +2,7 @@ import pytest
 
 from genno import Key
 from genno.core.key import iter_keys, single_key
+from genno.testing import raises_or_warns
 
 
 def test_key():
@@ -31,8 +32,7 @@ def test_key():
     assert Key("foo", tag="baz") == "foo::baz"
 
 
-_invalid = pytest.mark.xfail(raises=ValueError, reason="Invalid key expression")
-
+_invalid = pytest.raises(ValueError, match="Invalid key expression")
 
 CASES = (
     ("foo", Key("foo")),
@@ -46,20 +46,21 @@ CASES = (
     # Weird but not invalid
     ("foo::++", Key("foo", tag="++")),
     # Invalid
-    pytest.param(":", None, marks=_invalid),
-    pytest.param("::", None, marks=_invalid),
-    pytest.param("::bar", None, marks=_invalid),
-    pytest.param(":a-b:bar", None, marks=_invalid),
-    pytest.param("foo:a-b-", None, marks=_invalid),
+    (":", _invalid),
+    ("::", _invalid),
+    ("::bar", _invalid),
+    (":a-b:bar", _invalid),
+    ("foo:a-b-", _invalid),
     # Bad arguments
-    pytest.param(42.1, None, marks=pytest.mark.xfail(raises=TypeError)),
+    (42.1, pytest.raises(TypeError)),
 )
 
 
 class TestKey:
     @pytest.mark.parametrize("value, expected", CASES)
-    def test_init0(self, value, expected):
-        assert expected == Key(value)
+    def test_init0(self, value, expected) -> None:
+        with raises_or_warns(expected, None):
+            assert expected == Key(value)
 
     @pytest.mark.parametrize(
         "args, expected",
@@ -81,8 +82,8 @@ class TestKey:
         assert expected == Key(*args)
 
     @pytest.mark.parametrize("value, expected", CASES)
-    def test_from_str_or_key0(self, value, expected):
-        with pytest.warns(FutureWarning, match="no longer necessary"):
+    def test_from_str_or_key0(self, value, expected) -> None:
+        with raises_or_warns(expected, FutureWarning, match="no longer necessary"):
             assert expected == Key.from_str_or_key(value)
 
     @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "pandas >= 1.0",
   "pint",
   "PyYAML",
-  "setuptools >= 41",
   # 2022.6.0 is affected by pydata/xarray#6822
   "xarray >= 0.17, != 2022.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ filterwarnings = [
   # Upstream changes that won't affect genno
   "ignore:configure_currency.*will no longer be the default:DeprecationWarning:iam_units",
   "ignore:Jupyter is migrating its paths.*:DeprecationWarning:jupyter_client.connect",
+  # https://github.com/dateutil/dateutil/issues/1314
+  "ignore:datetime.datetime.utcfromtimestamp.. is deprecated.*:DeprecationWarning:dateutil",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
- Will close #120 / iiasa/message_ix#788.
- Also adjust for pytest 8.0.0, resolving recent CI failures.

  In particular, code like the following would pass in pytest <8 if `myfunc()` raised before emitting any warning:
  ```python
  with pytest.raises(...), pytest.warns(...):
      myfunc()
  ```

  From pytest 8.0, both conditions are mandatory: the exception must be raised **and** the warning emitted, or the block fails.

  The PR adds `genno.testing.raises_or_warns()` to handle mixed assertions.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, bugfix
- [x] Update doc/whatsnew.rst