### PR TITLE
Add dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  # Only update major versions
+  ignore:
+    - dependency-name: "*"
+      update-types:
+      - "version-update:semver-minor"
+      - "version-update:semver-patch"
+  # Below config mirrors the example at
+  # https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+    time: "16:00"
+  groups:
+    all-actions:
+      patterns: [ "*" ]


### PR DESCRIPTION
- Update all third-party GHA actions in a single weekly PR.
- Only make major version updates.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, CI changes only
- ~Update doc/whatsnew.rst~
