### PR TITLE
Move sphinx config to extensions

### DIFF
--- a/doc/api-testing.rst
+++ b/doc/api-testing.rst
@@ -1,8 +1,16 @@
-Test utilities and fixtures
-***************************
+Test and documentation utilities
+********************************
 
 .. automodule:: genno.testing
    :members:
 
 .. automodule:: genno.testing.jupyter
+   :members:
+
+.. automodule:: genno.compat.sphinx
+
+.. automodule:: genno.compat.sphinx.autodoc_operator
+   :members:
+
+.. automodule:: genno.compat.sphinx.rewrite_refs
    :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -71,12 +71,14 @@ reference_aliases = {
     "Quantity": "genno.core.attrseries.AttrSeries",
     "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
     #
-    # Many projects' inventories lack a py:module target for the top-level module.
-    # Rewrite these so that, for instance, :py:mod:`dask` becomes :std:doc:`dask:index`.
+    # Many projects (including Sphinx itself!) do not have a py:module target in for the
+    # top-level module in objects.inv. Resolve these using :doc:`index` or similar for
+    # each project.
     "dask$": ":std:doc:`dask:index`",
     "pint$": ":std:doc:`pint <pint:index>`",
     "plotnine$": ":class:`plotnine.ggplot`",
     "pyam$": ":std:doc:`pyam:index`",
+    "sphinx$": ":std:doc:`sphinx <sphinx:index>`",
 }
 
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
@@ -110,6 +112,7 @@ intersphinx_mapping = {
     "pytest": ("https://docs.pytest.org/en/stable", None),
     "sdmx1": ("https://sdmx1.readthedocs.io/en/stable", None),
     "sparse": ("https://sparse.pydata.org/en/stable", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
     "xarray": ("https://docs.xarray.dev/en/stable", None),
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,12 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import re
-
-from docutils.nodes import Text
-from sphinx.addnodes import pending_xref
-from sphinx.ext.intersphinx import missing_reference
-
 # -- Project information ---------------------------------------------------------------
 
 project = "genno"
@@ -22,7 +16,7 @@ author = "Genno contributors"
 # Add any Sphinx extension module names here, as strings. They can be extensions coming
 # with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    "IPython.sphinxext.ipython_directive",
+    # First-party
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
@@ -30,6 +24,10 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    # Others
+    "genno.compat.sphinx.autodoc_operator",
+    "genno.compat.sphinx.rewrite_refs",
+    "IPython.sphinxext.ipython_directive",
 ]
 
 # List of patterns, relative to source directory, that match files and directories to
@@ -47,28 +45,6 @@ rst_prolog = """
 # Paths that contain templates, relative to the current directory.
 templates_path = ["_templates"]
 
-
-def setup(app):
-    """Sphinx build setup."""
-    # Modify the sphinx.ext.autodoc config to handle Operators as functions
-    from sphinx.ext.autodoc import FunctionDocumenter
-
-    from genno.core.operator import Operator
-
-    class OperatorDocumenter(FunctionDocumenter):
-        @classmethod
-        def can_document_member(cls, member, membername, isattr, parent) -> bool:
-            return isinstance(member, Operator) or super().can_document_member(
-                member, membername, isattr, parent
-            )
-
-    app.add_autodocumenter(OperatorDocumenter, override=True)
-
-    # Connect reftarget_alias event handlers
-    app.connect("doctree-read", resolve_internal_aliases)
-    app.connect("missing-reference", resolve_intersphinx_aliases)
-
-
 # -- Options for HTML output -----------------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for a list of
@@ -85,6 +61,23 @@ html_theme_options = dict(
     use_repository_button=True,
     use_source_button=True,
 )
+
+# -- Options for genno.compat.sphinx.reference_alias -----------------------------------
+
+# Mapping from expression → replacement.
+# Order matters here; earlier entries are matched first.
+reference_aliases = {
+    r"Quantity\.units": "genno.core.base.UnitsMixIn.units",
+    "Quantity": "genno.core.attrseries.AttrSeries",
+    "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
+    #
+    # Many projects' inventories lack a py:module target for the top-level module.
+    # Rewrite these so that, for instance, :py:mod:`dask` becomes :std:doc:`dask:index`.
+    "dask$": ":std:doc:`dask:index`",
+    "pint$": ":std:doc:`pint <pint:index>`",
+    "plotnine$": ":class:`plotnine.ggplot`",
+    "pyam$": ":std:doc:`pyam:index`",
+}
 
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
 
@@ -141,70 +134,3 @@ napoleon_type_aliases = {
 # -- Options for sphinx.ext.todo -------------------------------------------------------
 
 todo_include_todos = True
-
-# -- Other configuration ---------------------------------------------------------------
-
-# Mapping from (expression) → (replacement, optional new text, optional new reftype).
-# Order matters here; earlier entries are matched first.
-#
-# h/t https://stackoverflow.com/a/62301461
-reftarget_alias = {
-    r"Quantity\.units": ("genno.core.base.UnitsMixIn.units", None, None),
-    "Quantity": ("genno.core.attrseries.AttrSeries", None, None),
-    "AnyQuantity": ("genno.core.quantity.AnyQuantity", None, "data"),
-    # Many projects' inventories lack a py:module target for the top-level module.
-    # Rewrite these so that, for instance, :py:mod:`dask` becomes :std:doc:`dask`.
-    "dask$": ("dask:index", None, "std:doc"),
-    "pint$": ("pint:index", "pint", "std:doc"),
-    "plotnine$": ("plotnine.ggplot", None, "class"),
-    "pyam$": ("pyam:index", None, "std:doc"),
-}
-
-
-def _apply_reftarget_alias(node):
-    """Apply `reftarget_alias` to `node`."""
-    try:
-        # Retrieve the "reftarget" attribute of the node
-        target = node["reftarget"]
-
-        # Identify an alias expression matching `reftarget`
-        expr = next(filter(lambda e: re.match(e, target), reftarget_alias))
-    except (KeyError, StopIteration):
-        # No such attribute, or no matching expression → nothing to do
-        return False
-
-    # Unpack information about the replacement
-    replacement, new_text, new_reftype = reftarget_alias[expr]
-
-    # Resolve the ref by substituting `replacement`
-    node["reftarget"] = re.sub(expr, replacement, target)
-
-    # Rewrite the rendered text
-    if new_text:
-        # Find the text node child
-        text_node = next(iter(node.traverse(lambda n: n.tagname == "#text")))
-        # Remove the old text node, add new text node with custom text
-        text_node.parent.replace(text_node, Text(new_text, ""))
-
-    # Rewrite the reftype
-    if new_reftype:
-        # Maybe split "foo:bar" to ref domain "foo" and ref type "bar"
-        *new_refdomain, new_reftype = new_reftype.split(":")
-        node["reftype"] = new_reftype
-        if new_refdomain:
-            node["refdomain"] = new_refdomain[0]
-
-    return True
-
-
-def resolve_internal_aliases(app, doctree):
-    """Handler for 'doctree-read' events."""
-    for node in doctree.traverse(condition=pending_xref):
-        _apply_reftarget_alias(node)
-
-
-def resolve_intersphinx_aliases(app, env, node, contnode):
-    """Handler for 'missing-reference' (intersphinx) events."""
-    if _apply_reftarget_alias(node):
-        # Delegate the rest of the work to intersphinx
-        return missing_reference(app, env, node, contnode)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Expose :mod:`sphinx` utilities as extensions in :mod:`genno.compat.sphinx` (:pull:`137`).
 
 v1.25.0 (2024-03-26)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -65,7 +65,7 @@ All changes
   This reduces file size and increases input/output speed.
 - If no other location is configured, cached files are stored and read in the :func:`.platformdirs.user_cache_path`,  (:pull:`135`).
 - :class:`.SparseDataArray` can be instantiated with :class:`int` data (:pull:`135`).
-  Because :mod:`sparse`` does not support nullable integer dtypes, values are automatically cast to :class:`float` and a warning is logged.
+  Because :mod:`sparse` does not support nullable integer dtypes, values are automatically cast to :class:`float` and a warning is logged.
 - Configuration handling is simplified using a :class:`.ConfigHandler` class (:pull:`135`).
 
 v1.24.1 (2024-03-14)

--- a/genno/compat/sphinx/autodoc_operator.py
+++ b/genno/compat/sphinx/autodoc_operator.py
@@ -1,0 +1,22 @@
+"""Configure :mod:`sphinx.ext.autodoc` to handle :class:`Operator` as functions."""
+
+from typing import TYPE_CHECKING
+
+from sphinx.ext.autodoc import FunctionDocumenter
+
+from genno.core.operator import Operator
+
+if TYPE_CHECKING:
+    import sphinx.application
+
+
+class OperatorDocumenter(FunctionDocumenter):
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent) -> bool:
+        return isinstance(member, Operator) or super().can_document_member(
+            member, membername, isattr, parent
+        )
+
+
+def setup(app: "sphinx.application.Sphinx"):
+    app.add_autodocumenter(OperatorDocumenter, override=True)

--- a/genno/compat/sphinx/autodoc_operator.py
+++ b/genno/compat/sphinx/autodoc_operator.py
@@ -1,5 +1,3 @@
-"""Configure :mod:`sphinx.ext.autodoc` to handle :class:`Operator` as functions."""
-
 from typing import TYPE_CHECKING
 
 from sphinx.ext.autodoc import FunctionDocumenter
@@ -19,4 +17,5 @@ class OperatorDocumenter(FunctionDocumenter):
 
 
 def setup(app: "sphinx.application.Sphinx"):
+    """Configure :mod:`sphinx.ext.autodoc` to handle :class:`Operator` as functions."""
     app.add_autodocumenter(OperatorDocumenter, override=True)

--- a/genno/compat/sphinx/rewrite_refs.py
+++ b/genno/compat/sphinx/rewrite_refs.py
@@ -92,7 +92,7 @@ def resolve_intersphinx_aliases(app, env, node, contnode):
 
 
 def setup(app: "sphinx.application.Sphinx"):
-    """Connect :mod:`rewrite_refs` event handlers."""
+    """Connect :mod:`.rewrite_refs` event handlers."""
 
     app.add_config_value("reference_aliases", dict(), "")
 

--- a/genno/compat/sphinx/rewrite_refs.py
+++ b/genno/compat/sphinx/rewrite_refs.py
@@ -1,0 +1,98 @@
+"""Resolve missing references using aliased target names, domains, and/or types.
+
+Expanded from and with thanks for https://stackoverflow.com/a/62301461.
+"""
+
+import re
+from typing import TYPE_CHECKING, Mapping, Optional
+
+from docutils.nodes import Text
+from sphinx.addnodes import pending_xref
+from sphinx.ext.intersphinx import missing_reference
+
+if TYPE_CHECKING:
+    import sphinx.application
+
+
+class Replacement:
+    refdomain: Optional[str]
+    reftype: Optional[str]
+    reftarget: str
+    text: Optional[str]
+
+    # Identifier characters
+    c = "[^`<>]+"
+
+    # Match any of:
+    # - ":domain:type:`text <target>`"
+    # - ":domain:type:`target`"
+    # - ":type:`text <target>`"
+    # - ":type:`target`"
+    # - "text <target>"
+    # - "target"
+    _target_expr = re.compile(
+        rf"(:((?P<rd>{c}):)?(?P<rt>{c}):)?(`?)(?P<t_or_t>{c})(<(?P<target>{c})>)?\5"
+    )
+
+    def __init__(self, value: str) -> None:
+        match = self._target_expr.fullmatch(value)
+        assert match is not None
+        self.refdomain, self.reftype, target_or_text, target = [
+            match.group(k) for k in ("rd", "rt", "t_or_t", "target")
+        ]
+        if target is None:  # Target only, no replacement text
+            self.reftarget, self.text = target_or_text, None
+        else:  # Both target and text replacement
+            self.reftarget, self.text = target, target_or_text.rstrip()
+
+
+def apply_alias(config: Mapping[str, str], node) -> bool:
+    """Apply `config` to `node`."""
+    try:
+        # Identify an alias expression matching the "reftarget" attribute of `node`
+        expr = next(filter(lambda e: re.match(e, node["reftarget"]), config))
+    except (KeyError, StopIteration):
+        # No such attribute, or no matching expression → nothing to do
+        return False
+
+    # Unpack information about the replacement
+    replace = Replacement(config[expr])
+
+    # Resolve the ref by substituting the reftarget for the matching part
+    node["reftarget"] = re.sub(f"^{expr}", replace.reftarget, node["reftarget"])
+
+    # Rewrite the rendered text, reftype, and refdomain
+    if replace.text:
+        # Find the text node child
+        text_node = next(iter(node.traverse(lambda n: n.tagname == "#text")))
+        # Remove the old text node, add new text node with custom text
+        text_node.parent.replace(text_node, Text(replace.text))
+    if replace.reftype:
+        node["reftype"] = replace.reftype
+    if replace.refdomain:
+        node["refdomain"] = replace.refdomain
+
+    return True
+
+
+def resolve_internal_aliases(app: "sphinx.application.Sphinx", doctree):
+    """Handler for 'doctree-read' events."""
+    config = app.config["reference_aliases"]
+    for node in doctree.traverse(condition=pending_xref):
+        apply_alias(config, node)
+
+
+def resolve_intersphinx_aliases(app, env, node, contnode):
+    """Handler for 'missing-reference' (intersphinx) events."""
+    if apply_alias(app.config["reference_aliases"], node):
+        # Delegate the rest of the work to intersphinx
+        return missing_reference(app, env, node, contnode)
+
+
+def setup(app: "sphinx.application.Sphinx"):
+    """Connect reference_alias event handlers."""
+
+    app.add_config_value("reference_aliases", dict(), "")
+
+    app.connect("doctree-read", resolve_internal_aliases)
+    app.connect("missing-reference", resolve_intersphinx_aliases)

--- a/genno/compat/sphinx/rewrite_refs.py
+++ b/genno/compat/sphinx/rewrite_refs.py
@@ -67,6 +67,8 @@ def apply_alias(config: Mapping[str, str], node) -> bool:
         text_node = next(iter(node.traverse(lambda n: n.tagname == "#text")))
         # Remove the old text node, add new text node with custom text
         text_node.parent.replace(text_node, Text(replace.text))
+        # Force further processing to preserve this text node
+        node["refexplicit"] = True
     if replace.reftype:
         node["reftype"] = replace.reftype
     if replace.refdomain:
@@ -90,7 +92,7 @@ def resolve_intersphinx_aliases(app, env, node, contnode):
 
 
 def setup(app: "sphinx.application.Sphinx"):
-    """Connect reference_alias event handlers."""
+    """Connect :mod:`rewrite_refs` event handlers."""
 
     app.add_config_value("reference_aliases", dict(), "")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ repository = "https://github.com/khaeru/genno"
 documentation = "https://genno.rtfd.io/en/stable/"
 
 [tool.coverage.report]
+omit = [
+  "**/genno/compat/sphinx/*",
+]
 exclude_also = [
   # Imports only used by type checkers
   "if TYPE_CHECKING:",


### PR DESCRIPTION
This will allow re-use in downstream projects, such as ixmp

For now, we avoid building up test infrastructure for these and omit the extensions from coverage metrics.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- [x] Update doc/whatsnew.rst
