### PR TITLE
Adjust CI for Python 3.8, 3.9 on macOS

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -41,6 +41,14 @@ jobs:
         # from CI.
         # - {version: "3.13.0-rc.1", extras: ""}  # Development version
 
+        # Work around https://github.com/actions/setup-python/issues/696
+        exclude:
+        - {os: macos-latest, python: {version: "3.8", extras: ",sparse"}}
+        - {os: macos-latest, python: {version: "3.9", extras: ",sparse"}}
+        include:
+        - {os: macos-13, python: {version: "3.8", extras: ",sparse"}}
+        - {os: macos-13, python: {version: "3.9", extras: ",sparse"}}
+
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     - xarray
     args: []
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.2
+  rev: v0.4.1
   hooks:
   - id: ruff
   - id: ruff-format


### PR DESCRIPTION
Work around https://github.com/actions/setup-python/issues/696#issuecomment-2072959905, in a similar way others appear to be doing.

Per other resources, this may be eventually resolved by upstream changes. If so, the fix could be reverted.
- actions/setup-python#808
- python/peps#3763
- https://mastodon.social/@hugovk/112320493602782374

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, CI changes only.
- ~Update doc/whatsnew.rst~
