### PR TITLE
Confirm support for Python 3.13 and drop 3.8

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,12 +27,12 @@ jobs:
         # release. Only test SparseDataArray where possible.
         # Earliest version supported by genno = earliest Python that has not
         # reached EOL
-        - {version: "3.9", extras: ",sparse"}
-        - {version: "3.10", extras: ",sparse"}
-        - {version: "3.11", extras: ",sparse"}
-        - {version: "3.12", extras: ",sparse"}
+        - {version: "3.9", extras: ".[sparse]"}
+        - {version: "3.10", extras: ".[sparse]"}
+        - {version: "3.11", extras: ".[sparse]"}
+        - {version: "3.12", extras: ".[sparse]"}
         # Latest release / latest supported by genno / testable on GHA
-        - {version: "3.13", extras: ""}
+        - {version: "3.13", extras: '"Pint > 0.24"'}
 
         # For fresh releases and development versions of Python, compiled binary
         # wheels are not available for some dependencies, e.g. numpy, pandas.
@@ -62,7 +62,7 @@ jobs:
         macos-skip-brew-update: true
 
     - name: Install the Python package and dependencies
-      run: pip install --upgrade --upgrade-strategy=eager .[tests${{ matrix.python.extras }}]
+      run: pip install --upgrade --upgrade-strategy=eager .[tests] ${{ matrix.python.extras }}
 
     - name: Run test suite using pytest
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,15 +30,16 @@ jobs:
         - {version: "3.9", extras: ",sparse"}
         - {version: "3.10", extras: ",sparse"}
         - {version: "3.11", extras: ",sparse"}
-        # Latest release / latest supported by genno / testable on GHA
         - {version: "3.12", extras: ",sparse"}
+        # Latest release / latest supported by genno / testable on GHA
+        - {version: "3.13", extras: ""}
 
         # For fresh releases and development versions of Python, compiled binary
         # wheels are not available for some dependencies, e.g. numpy, pandas.
         # Compiling these on the job runner requires a more elaborate build
         # environment, currently out of scope for genno. Exclude these versions
         # from CI.
-        # - {version: "3.13.0-rc.1", extras: ""}  # Development version
+        # - {version: "3.14.0-beta.1", extras: ""}  # Development version
 
       fail-fast: false
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,6 +77,7 @@ reference_aliases = {
     "dask$": ":std:doc:`dask:index`",
     "pint$": ":std:doc:`pint <pint:index>`",
     "plotnine$": ":class:`plotnine.ggplot`",
+    "pyarrow$": ":std:doc:`pyarrow <pyarrow:python/index>`",
     "pyam$": ":std:doc:`pyam:index`",
     "sphinx$": ":std:doc:`sphinx <sphinx:index>`",
 }
@@ -108,6 +109,7 @@ intersphinx_mapping = {
     "platformdirs": ("https://platformdirs.readthedocs.io/en/latest", None),
     "plotnine": ("https://plotnine.org", None),
     "pyam": ("https://pyam-iamc.readthedocs.io/en/stable", None),
+    "pyarrow": ("https://arrow.apache.org/docs", None),
     "python": ("https://docs.python.org/3", None),
     "pytest": ("https://docs.pytest.org/en/stable", None),
     "sdmx1": ("https://sdmx1.readthedocs.io/en/stable", None),

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,7 +4,14 @@ What's new
 Next release
 ============
 
-- genno is compatible and tested with `NumPy 2.0 <https://numpy.org/doc/stable/release/2.0.0-notes.html>`_, released 2024-06-16 (:issue:`140`, :pull:`141`).
+- :mod:`genno` supports and is tested on:
+
+  - `Python 3.13 <https://www.python.org/downloads/release/python-3130/>`_, released 2024-10-07 (:pull:`143`).
+    As of release time, support for :class:`.SparseDataArray` awaits :mod:`sparse`, thus `numba <https://github.com/numba/numba/issues/9413>`__ and `llvmlite <https://github.com/numba/llvmlite/issues/1084>`__.
+    :class:`.SparseDataArray` should be usable once these dependencies are updated.
+  - `NumPy 2.0 <https://numpy.org/doc/stable/release/2.0.0-notes.html>`_, released 2024-06-16 (:issue:`140`, :pull:`141`).
+
+- Support for Python 3.8 is dropped (:pull:`143`), as it has reached end-of-life.
 
 v1.26.0 (2024-03-27)
 ====================

--- a/genno/caching.py
+++ b/genno/caching.py
@@ -5,7 +5,7 @@ from functools import partial, singledispatch, update_wrapper
 from hashlib import blake2b
 from inspect import getmembers, iscode
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import pandas as pd
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Types to ignore in Encoder.default()
-IGNORE: Set[type] = set()
+IGNORE: set[type] = set()
 
 
 @singledispatch

--- a/genno/compat/graphviz.py
+++ b/genno/compat/graphviz.py
@@ -1,6 +1,6 @@
 import re
 from os import PathLike
-from typing import Literal, Mapping, Optional, Set, Union
+from typing import Literal, Mapping, Optional, Union
 
 from genno.core.describe import is_list_of_keys, label
 
@@ -55,9 +55,9 @@ class Visualizer:
         self.graph = Digraph(graph_attr=self.ga, node_attr=na, edge_attr=edge_attr)
 
         # Nodes or edges already seen
-        self.seen: Set[str] = set()
+        self.seen: set[str] = set()
         # Nodes already connected to the graph
-        self.connected: Set[str] = set()
+        self.connected: set[str] = set()
 
     def get_attrs(self, kind: Literal["data", "func"], name: str, **defaults) -> dict:
         """Prepare attributes for a node of `kind`.

--- a/genno/compat/pint.py
+++ b/genno/compat/pint.py
@@ -11,13 +11,12 @@ Notes:
 """
 
 from importlib.metadata import version
-from typing import Tuple, Type
 
 import pint
 
 try:
-    PintError: Tuple[Type[Exception], ...] = (pint.PintError,)
-    ApplicationRegistry: Type = pint.ApplicationRegistry
+    PintError: tuple[type[Exception], ...] = (pint.PintError,)
+    ApplicationRegistry: type = pint.ApplicationRegistry
 except AttributeError:  # pragma: no cover
     # Older versions of pint, e.g. 0.17
     PintError = (type("PintError", (Exception,), {}), pint.DefinitionSyntaxError)

--- a/genno/compat/plotnine/plot.py
+++ b/genno/compat/plotnine/plot.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Hashable, Optional, Sequence
+from typing import Any, Hashable, Optional, Sequence
 from warnings import warn
 
 import plotnine as p9
@@ -31,7 +31,7 @@ class Plot(ABC):
     #: accepted by :meth:`generate`.
     inputs: Sequence[Hashable] = []
     #: Keyword arguments for :any:`plotnine.ggplot.save`.
-    save_args: Dict[str, Any] = dict(verbose=False)
+    save_args: dict[str, Any] = dict(verbose=False)
 
     # TODO add static geoms automatically in generate()
     __static: Sequence = []

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -1,7 +1,6 @@
 import logging
 from functools import partial
 from importlib.util import find_spec
-from typing import List
 
 from genno import Computer, Key
 from genno.config import handles
@@ -31,7 +30,7 @@ def iamc(c: Computer, info):
     name = info.pop("variable")
 
     # Chain of keys produced: first entry is the key for the base quantity
-    keys: List[Key] = [Key(info.pop("base"))]
+    keys: list[Key] = [Key(info.pop("base"))]
 
     # Second entry is a simple rename
     keys.append(single_key(c.add_single(Key(name, keys[0].dims, keys[0].tag), keys[0])))

--- a/genno/compat/sdmx/operator.py
+++ b/genno/compat/sdmx/operator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Hashable, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import Hashable, Iterable, Mapping, Optional, Union
 
 import genno
 from genno import Quantity
@@ -23,7 +23,7 @@ __all__ = [
 def codelist_to_groups(
     codes: Union["sdmx.model.common.Codelist", Iterable["sdmx.model.common.Code"]],
     dim: Optional[str] = None,
-) -> Mapping[str, Mapping[str, List[str]]]:
+) -> Mapping[str, Mapping[str, list[str]]]:
     """Convert `codes` into a mapping from parent items to their children.
 
     The returned value is suitable for use with :func:`~.operator.aggregate`.
@@ -74,7 +74,7 @@ def dataset_to_quantity(ds: "sdmx.model.common.BaseDataSet") -> Quantity:
           of `ds`, if any.
     """
     # Assemble attributes
-    attrs: Dict[str, str] = {}
+    attrs: dict[str, str] = {}
     if ds.described_by:  # pragma: no cover
         attrs.update(dataflow_urn=util.urn(ds.described_by))
     if ds.structured_by:
@@ -139,7 +139,7 @@ def quantity_to_dataset(
         series_dims = list(dims[:od_index] + dims[od_index + 1 :])
         grouped: Iterable = qty.to_series().groupby(series_dims)
         # For as_obs()
-        obs_dims: Tuple[Hashable, ...] = (od.id,)
+        obs_dims: tuple[Hashable, ...] = (od.id,)
         key_slice = slice(od_index, od_index + 1)
     else:
         # Pseudo-groupby object

--- a/genno/compat/sdmx/util.py
+++ b/genno/compat/sdmx/util.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Type, Union
+from typing import Optional, Union
 
 import sdmx
 
@@ -29,10 +29,10 @@ def urn(obj: "sdmx.model.common.MaintainableArtefact") -> str:
 
 def handle_version(
     version: Union["sdmx.format.Version", str, None],
-) -> Tuple[
+) -> tuple[
     "sdmx.format.Version",
-    Type["sdmx.model.common.BaseDataSet"],
-    Type["sdmx.model.common.BaseObservation"],
+    type["sdmx.model.common.BaseDataSet"],
+    type["sdmx.model.common.BaseObservation"],
 ]:
     """Handle `version` arguments for :mod:`.sdmx.operator`.
 

--- a/genno/compat/xarray.py
+++ b/genno/compat/xarray.py
@@ -11,7 +11,6 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -74,11 +73,11 @@ class DataArrayLike(Protocol):
 
     @property
     @abstractmethod
-    def dims(self) -> Tuple[Hashable, ...]: ...
+    def dims(self) -> tuple[Hashable, ...]: ...
 
     @property
     @abstractmethod
-    def shape(self) -> Tuple[int, ...]: ...
+    def shape(self) -> tuple[int, ...]: ...
 
     @property
     @abstractmethod
@@ -204,7 +203,7 @@ class DataArrayLike(Protocol):
     @abstractmethod
     def pipe(
         self,
-        func: Union[Callable[..., T], Tuple[Callable[..., T], str]],
+        func: Union[Callable[..., T], tuple[Callable[..., T], str]],
         *args: Any,
         **kwargs: Any,
     ): ...

--- a/genno/config.py
+++ b/genno/config.py
@@ -6,16 +6,11 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
-    List,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
-    Set,
-    Tuple,
-    Type,
     Union,
 )
 from warnings import warn
@@ -29,7 +24,7 @@ from genno.util import REPLACE_UNITS
 log = logging.getLogger(__name__)
 
 #: Registry of configuration section handlers.
-HANDLERS: Dict[str, "ConfigHandler"] = {}
+HANDLERS: dict[str, "ConfigHandler"] = {}
 
 #: .. deprecated:: 1.25.0
 #:    Instead, use:
@@ -41,7 +36,7 @@ HANDLERS: Dict[str, "ConfigHandler"] = {}
 #:       handles("section_name", False, False)(store)
 #:
 #: Configuration sections/keys to be stored with no action.
-STORE: Set[str] = set()
+STORE: set[str] = set()
 
 
 def configure(path: Optional[Union[Path, str]] = None, **config):
@@ -182,7 +177,7 @@ def parse_config(
     data = PathHandler().handle(data, c)
 
     # Assemble a queue of (args, kwargs) for Computer.add_queue()
-    queue: List[Tuple[Tuple, Dict]] = []
+    queue: list[tuple[tuple, dict]] = []
 
     # Sections to discard, e.g. with handler._store = False
     discard = set()
@@ -341,7 +336,7 @@ def general(c: Computer, info):
             # log.debug(f"Inferred dimensions ({', '.join(key.dims)}) for '*'")
 
         # If info["comp"] is None, the task is a list that collects other keys
-        _seq: Type = list
+        _seq: type = list
         task = []
 
         if info["comp"] is not None:

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -10,7 +10,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Tuple,
     Union,
     cast,
 )
@@ -249,13 +248,13 @@ class AttrSeries(BaseQuantity, pd.Series, DataArrayLike):
         return self.values
 
     @property
-    def dims(self) -> Tuple[Hashable, ...]:
+    def dims(self) -> tuple[Hashable, ...]:
         """Like :attr:`xarray.DataArray.dims`."""
         # If 0-D, the single dimension has name `None` → discard
         return tuple(filter(None, self.index.names))
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Like :attr:`xarray.DataArray.shape`."""
         idx = self.index.remove_unused_levels()
         return tuple(len(idx.levels[i]) for i in map(idx.names.index, self.dims))
@@ -294,7 +293,10 @@ class AttrSeries(BaseQuantity, pd.Series, DataArrayLike):
         return self.droplevel(names)
 
     def expand_dims(self, dim=None, axis=None, **dim_kwargs: Any) -> "AttrSeries":
-        """Like :meth:`xarray.DataArray.expand_dims`."""
+        """Like :meth:`xarray.DataArray.expand_dims`.
+
+        .. todo:: Support passing a mapping of length > 1 to `dim`.
+        """
         if isinstance(dim, list):
             dim = dict.fromkeys(dim, [])
         dim = either_dict_or_kwargs(dim, dim_kwargs, "expand_dims")
@@ -620,7 +622,7 @@ class AttrSeries(BaseQuantity, pd.Series, DataArrayLike):
     # Internal methods
     def align_levels(
         self, other: "AttrSeries"
-    ) -> Tuple[Sequence[Hashable], "AttrSeries"]:
+    ) -> tuple[Sequence[Hashable], "AttrSeries"]:
         """Return a copy of `self` with ≥1 dimension(s) in the same order as `other`.
 
         Work-around for https://github.com/pandas-dev/pandas/issues/25760 and other

--- a/genno/core/base.py
+++ b/genno/core/base.py
@@ -4,14 +4,12 @@ from numbers import Number
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Generic,
     Hashable,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -30,7 +28,7 @@ if TYPE_CHECKING:
 class UnitsMixIn:
     """Object with :attr:`.units` and :meth:`._binary_op_units`."""
 
-    attrs: Dict[Hashable, Any]
+    attrs: dict[Hashable, Any]
 
     @property
     # def units(self) -> "Unit":
@@ -60,7 +58,7 @@ class UnitsMixIn:
 
     def _binary_op_units(
         self, other: "UnitsMixIn", op, swap: bool
-    ) -> Tuple["Unit", float]:
+    ) -> tuple["Unit", float]:
         """Determine result units for a binary operation between `self` and `other`.
 
         Returns:
@@ -177,12 +175,12 @@ class BaseQuantity(
     def __init__(
         self,
         data: Any = None,
-        coords: Union[Sequence[Tuple], Mapping[Hashable, Any], None] = None,
+        coords: Union[Sequence[tuple], Mapping[Hashable, Any], None] = None,
         dims: Union[str, Sequence[Hashable], None] = None,
         name: Hashable = None,
         attrs: Optional[Mapping] = None,
         # internal parameters
-        indexes: Optional[Dict[Hashable, pd.Index]] = None,
+        indexes: Optional[dict[Hashable, pd.Index]] = None,
         fastpath: bool = False,
         **kwargs,
     ): ...
@@ -217,7 +215,7 @@ class BaseQuantity(
 
 def prepare_binary_op(
     obj: BaseQuantity, other, op, swap: bool
-) -> Tuple[BaseQuantity, BaseQuantity, "Unit", float]:
+) -> tuple[BaseQuantity, BaseQuantity, "Unit", float]:
     """Prepare inputs for a binary operation.
 
     Returns:
@@ -274,7 +272,7 @@ def rank(op) -> int:
     }[op]
 
 
-def single_column_df(data, name: Hashable) -> Tuple[Any, Hashable]:
+def single_column_df(data, name: Hashable) -> tuple[Any, Hashable]:
     """Handle `data` and `name` arguments to Quantity constructors."""
     if isinstance(data, pd.DataFrame):
         if len(data.columns) != 1:

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -12,12 +12,10 @@ from typing import (
     Callable,
     Hashable,
     Iterable,
-    List,
     Mapping,
     MutableSequence,
     Optional,
     Sequence,
-    Tuple,
     Union,
     cast,
 )
@@ -247,7 +245,7 @@ class Computer:
 
     # Add computations to the Computer
 
-    def add(self, data, *args, **kwargs) -> Union[KeyLike, Tuple[KeyLike, ...]]:
+    def add(self, data, *args, **kwargs) -> Union[KeyLike, tuple[KeyLike, ...]]:
         """General-purpose method to add computations.
 
         :meth:`add` can be called in several ways; its behaviour depends on `data`; see
@@ -339,10 +337,10 @@ class Computer:
 
     def add_queue(  # noqa: C901  FIXME reduce complexity from 11 → ≤10
         self,
-        queue: Iterable[Tuple],
+        queue: Iterable[tuple],
         max_tries: int = 1,
         fail: Optional[Union[str, int]] = None,
-    ) -> Tuple[KeyLike, ...]:
+    ) -> tuple[KeyLike, ...]:
         """Add tasks from a list or `queue`.
 
         Parameters
@@ -366,7 +364,7 @@ class Computer:
             fail = self._queue_fail[-1]  # Use the same value as an outer call.
 
         # Accumulate added keys
-        added: List[KeyLike] = []
+        added: list[KeyLike] = []
 
         class Item:
             """Container for queue items."""
@@ -504,7 +502,7 @@ class Computer:
 
     def apply(
         self, generator: Callable, *keys, **kwargs
-    ) -> Union[KeyLike, Tuple[KeyLike, ...]]:
+    ) -> Union[KeyLike, tuple[KeyLike, ...]]:
         """Add computations by applying `generator` to `keys`.
 
         Parameters
@@ -529,7 +527,7 @@ class Computer:
         kwargs
             Keyword arguments to `generator`.
         """
-        args: List[Any] = self.check_keys(*keys)
+        args: list[Any] = self.check_keys(*keys)
 
         try:
             # Inspect the generator function
@@ -562,7 +560,7 @@ class Computer:
 
             return tuple(result) if len(result) > 1 else result[0]
 
-    def eval(self, expr: str) -> Tuple[Key, ...]:
+    def eval(self, expr: str) -> tuple[Key, ...]:
         r"""Evaluate `expr` to add tasks and keys.
 
         Parse a statement or block of statements using :mod:`.ast` from the Python
@@ -678,7 +676,7 @@ class Computer:
 
     def check_keys(
         self, *keys: Union[str, Key], predicate=None, action="raise"
-    ) -> List[KeyLike]:
+    ) -> list[KeyLike]:
         """Check that `keys` are in the Computer.
 
         Parameters
@@ -929,7 +927,7 @@ class Computer:
                 raise NotImplementedError("aggregate() along >1 dimension")
 
             key = Key(qty).add_tag(tag)
-            args: Tuple[Any, ...] = (
+            args: tuple[Any, ...] = (
                 operator.aggregate,
                 qty,
                 dask.core.quote(groups),

--- a/genno/core/eval.py
+++ b/genno/core/eval.py
@@ -18,14 +18,6 @@ BINOP = {
 }
 
 
-def unparse(node) -> str:
-    """Compatibility with Python ≤3.9, where :func:`ast.unparse` is not yet defined."""
-    try:
-        return ast.unparse(node)
-    except AttributeError:  # Python 3.8
-        return repr(node)
-
-
 class Parser:
     """Parser for :meth:`.Computer.eval`."""
 
@@ -111,7 +103,7 @@ class Parser:
     def _(self, node: ast.Call):
         if not isinstance(node.func, ast.Name):
             raise NotImplementedError(
-                f"Call {unparse(node.func)}(…) instead of function"
+                f"Call {ast.unparse(node.func)}(…) instead of function"
             )
 
         # Get the computation function
@@ -144,6 +136,6 @@ class Parser:
     def _(self, node: ast.keyword):
         if not isinstance(node.value, ast.Constant):
             raise NotImplementedError(
-                f"Non-literal keyword arg {unparse(node.value)!r}"
+                f"Non-literal keyword arg {ast.unparse(node.value)!r}"
             )
         return (node.arg, node.value.value)

--- a/genno/core/graph.py
+++ b/genno/core/graph.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator, Sequence
 from itertools import chain, tee
 from operator import itemgetter
-from typing import Any, Dict, Iterable, Optional, Union
+from typing import Any, Iterable, Optional, Union
 
 from .key import Key, KeyLike
 
@@ -29,8 +29,8 @@ class Graph(dict):
        infer
     """
 
-    _unsorted: Dict[KeyLike, KeyLike] = dict()
-    _full: Dict[Key, Key] = dict()
+    _unsorted: dict[KeyLike, KeyLike] = dict()
+    _full: dict[Key, Key] = dict()
 
     def __init__(self, *args, **kwargs):
         # Initialize members

--- a/genno/core/key.py
+++ b/genno/core/key.py
@@ -6,7 +6,6 @@ from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     Generator,
     Hashable,
     Iterable,
@@ -14,7 +13,6 @@ from typing import (
     Optional,
     Sequence,
     SupportsInt,
-    Tuple,
     Union,
 )
 from warnings import warn
@@ -36,7 +34,7 @@ BARE_STR = re.compile(r"^\s*(?P<name>[^:]+)\s*$")
 
 
 @singledispatch
-def _name_dims_tag(value) -> Tuple[str, Tuple[str, ...], Optional[str]]:
+def _name_dims_tag(value) -> tuple[str, tuple[str, ...], Optional[str]]:
     """Convert various `value`s into (name, dims, tag) tuples.
 
     Helper for :meth:`.Key.__init__`.
@@ -69,7 +67,7 @@ class Key:
     """A hashable key for a quantity that includes its dimensionality."""
 
     _name: str
-    _dims: Tuple[str, ...]
+    _dims: tuple[str, ...]
     _tag: Optional[str]
 
     def __init__(
@@ -175,7 +173,7 @@ class Key:
             return base
 
         # mypy is fussy here
-        drop_args: Tuple[Union[str, bool], ...] = tuple(
+        drop_args: tuple[Union[str, bool], ...] = tuple(
             [drop] if isinstance(drop, bool) else drop
         )
 
@@ -284,7 +282,7 @@ class Key:
         return self._name
 
     @property
-    def dims(self) -> Tuple[str, ...]:
+    def dims(self) -> tuple[str, ...]:
         """Dimensions of the quantity, :class:`tuple` of :class:`str`."""
         return self._dims
 
@@ -325,7 +323,7 @@ class Key:
             self._name, self._dims, "+".join(filter(None, [self._tag, tag])), _fast=True
         )
 
-    def iter_sums(self) -> Generator[Tuple["Key", Callable, "Key"], None, None]:
+    def iter_sums(self) -> Generator[tuple["Key", Callable, "Key"], None, None]:
         """Generate (key, task) for all possible partial sums of the Key."""
         from genno.operator import sum
 
@@ -364,7 +362,7 @@ class KeySeq:
     base: Key
 
     # Keys that have been created.
-    _keys: Dict[Hashable, Key]
+    _keys: dict[Hashable, Key]
 
     def __init__(self, *args, **kwargs):
         self.base = Key(*args, **kwargs)
@@ -408,7 +406,7 @@ class KeySeq:
         return self.base.name
 
     @property
-    def dims(self) -> Tuple[str, ...]:
+    def dims(self) -> tuple[str, ...]:
         """Dimensions of the :attr:`.base` Key."""
         return self.base.dims
 
@@ -444,7 +442,7 @@ def combo_partition(iterable):
         yield list(compress(iterable, a)), list(compress(iterable, b))
 
 
-def iter_keys(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Iterator[Key]:
+def iter_keys(value: Union[KeyLike, tuple[KeyLike, ...]]) -> Iterator[Key]:
     """Yield :class:`Keys <Key>` from `value`.
 
     Raises
@@ -467,7 +465,7 @@ def iter_keys(value: Union[KeyLike, Tuple[KeyLike, ...]]) -> Iterator[Key]:
         yield element
 
 
-def single_key(value: Union[KeyLike, Tuple[KeyLike, ...], Iterator]) -> Key:
+def single_key(value: Union[KeyLike, tuple[KeyLike, ...], Iterator]) -> Key:
     """Ensure `value` is a single :class:`Key`.
 
     Raises

--- a/genno/core/operator.py
+++ b/genno/core/operator.py
@@ -1,6 +1,6 @@
 from functools import update_wrapper
 from inspect import signature
-from typing import Any, Callable, ClassVar, Dict, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Optional, Union
 from warnings import warn
 
 from .computer import Computer
@@ -39,7 +39,7 @@ class Operator:
     #: Function or callable for the Operator.
     func: ClassVar[Callable]
     args = ()
-    keywords: Dict[str, Any] = dict()
+    keywords: dict[str, Any] = dict()
 
     #: Helper method to add tasks to a :class:`.Computer`. Register with :meth:`helper`,
     #: invoke with :meth:`add_tasks`.
@@ -112,13 +112,13 @@ class Operator:
         return decorator
 
     def helper(
-        self, func: Callable[..., Union[KeyLike, Tuple[KeyLike, ...]]]
+        self, func: Callable[..., Union[KeyLike, tuple[KeyLike, ...]]]
     ) -> Callable:
         """Register `func` as the convenience method for adding task(s)."""
         self.__class__._add_tasks = staticmethod(func)
         return func
 
-    def add_tasks(self, c: "Computer", *args, **kwargs) -> Tuple[KeyLike, ...]:
+    def add_tasks(self, c: "Computer", *args, **kwargs) -> tuple[KeyLike, ...]:
         """Invoke :attr:`_add_task` to add tasks to `c`."""
         if self._add_tasks is None:
             raise NotImplementedError

--- a/genno/core/sparsedataarray.py
+++ b/genno/core/sparsedataarray.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Hashable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Hashable, Mapping, Optional, Sequence, Union
 from warnings import filterwarnings
 
 import numpy as np
@@ -118,17 +118,17 @@ class SparseDataArray(BaseQuantity, OverrideItem, xr.DataArray):
     data.
     """
 
-    __slots__: Tuple[str, ...] = tuple()
+    __slots__: tuple[str, ...] = tuple()
 
     def __init__(
         self,
         data: Any = dtypes.NA,
-        coords: Union[Sequence[Tuple], Mapping[Hashable, Any], None] = None,
+        coords: Union[Sequence[tuple], Mapping[Hashable, Any], None] = None,
         dims: Union[str, Sequence[Hashable], None] = None,
         name: Hashable = None,
         attrs: Optional[Mapping] = None,
         # internal parameters
-        indexes: Optional[Dict[Hashable, pd.Index]] = None,
+        indexes: Optional[dict[Hashable, pd.Index]] = None,
         fastpath: bool = False,
         **kwargs,
     ):

--- a/genno/operator.py
+++ b/genno/operator.py
@@ -17,10 +17,8 @@ from typing import (
     Collection,
     Hashable,
     Iterable,
-    List,
     Mapping,
     Optional,
-    Tuple,
     Union,
     cast,
 )
@@ -197,7 +195,7 @@ def aggregate(
                 )
 
             # Handle regular expressions in `members`; skip items not in `coords`
-            mem: List[Hashable] = []
+            mem: list[Hashable] = []
             for m in members:
                 if isinstance(m, re.Pattern):
                     mem.extend(filter(m.fullmatch, coords))
@@ -384,8 +382,8 @@ def clip(
 
 def combine(
     *quantities: "AnyQuantity",
-    select: Optional[List[Mapping]] = None,
-    weights: Optional[List[float]] = None,
+    select: Optional[list[Mapping]] = None,
+    weights: Optional[list[float]] = None,
 ) -> "AnyQuantity":  # noqa: F811
     """Sum distinct `quantities` by `weights`.
 
@@ -979,7 +977,7 @@ def sub(a: "AnyQuantity", b: "AnyQuantity") -> "AnyQuantity":
 def sum(
     quantity: "AnyQuantity",
     weights: Optional["AnyQuantity"] = None,
-    dimensions: Optional[List[str]] = None,
+    dimensions: Optional[list[str]] = None,
 ) -> "AnyQuantity":
     """Sum `quantity` over `dimensions`, with optional `weights`.
 
@@ -1006,7 +1004,7 @@ def sum(
 @sum.helper
 def add_sum(
     func, c: "genno.Computer", key, qty, weights=None, dimensions=None, **kwargs
-) -> Union[KeyLike, Tuple[KeyLike, ...]]:
+) -> Union[KeyLike, tuple[KeyLike, ...]]:
     """:meth:`.Computer.add` helper for :func:`.sum`.
 
     If `key` has the name "*", the returned key has name and dimensions inferred from

--- a/genno/testing/__init__.py
+++ b/genno/testing/__init__.py
@@ -5,7 +5,7 @@ from contextlib import nullcontext
 from functools import partial
 from importlib.metadata import version
 from itertools import chain, islice
-from typing import TYPE_CHECKING, ContextManager, Dict
+from typing import TYPE_CHECKING, ContextManager
 
 import numpy as np
 import pandas as pd
@@ -410,7 +410,7 @@ def assert_units(qty: "AnyQuantity", exp: str) -> None:
     ).dimensionless, f"Units '{qty.units:~}'; expected {repr(exp)}"
 
 
-def random_qty(shape: Dict[str, int], **kwargs) -> "AnyQuantity":
+def random_qty(shape: dict[str, int], **kwargs) -> "AnyQuantity":
     """Return a Quantity with `shape` and random contents.
 
     Parameters

--- a/genno/tests/compat/test_plotnine.py
+++ b/genno/tests/compat/test_plotnine.py
@@ -50,7 +50,6 @@ def test_Plot(caplog, tmp_path):
     with pytest.raises(
         TypeError,
         # Messages vary by Python version:
-        # - ≤3.8    : "…with abstract methods generate"
         # - 3.9–3.11: "…with abstract method generate" (no s)
         # - 3.12    : "…without an implementation for abstract method 'generate'"
         match=(

--- a/genno/tests/compat/test_plotnine.py
+++ b/genno/tests/compat/test_plotnine.py
@@ -116,9 +116,10 @@ def test_Plot_deprecated(caplog, tmp_path):
     c.get("plot")
 
     # Raised during add(…, strict=True)
-    with pytest.raises(
-        MissingKeyError, match=re.escape("required keys ('notakey',)")
-    ), pytest.warns(DeprecationWarning):
+    with (
+        pytest.raises(MissingKeyError, match=re.escape("required keys ('notakey',)")),
+        pytest.warns(DeprecationWarning),
+    ):
         c.add("plot4", Plot4.make_task(), strict=True)
 
     # Logged during get()

--- a/genno/tests/core/test_computer.py
+++ b/genno/tests/core/test_computer.py
@@ -151,8 +151,9 @@ class TestComputer:
 
         # aggregate() calls add(), which raises the exception
         g = Key("g", "hi")
-        with pytest.raises(MissingKeyError, match=msg(g)), pytest.warns(
-            DeprecationWarning
+        with (
+            pytest.raises(MissingKeyError, match=msg(g)),
+            pytest.warns(DeprecationWarning),
         ):
             c.aggregate(g, "tag", "i")
 
@@ -178,8 +179,9 @@ class TestComputer:
 
         # MissingKeyError is raised
         g = Key("g", "hi")
-        with pytest.raises(MissingKeyError, match=msg(g)), pytest.warns(
-            DeprecationWarning
+        with (
+            pytest.raises(MissingKeyError, match=msg(g)),
+            pytest.warns(DeprecationWarning),
         ):
             c.disaggregate(g, "j")
 
@@ -459,16 +461,18 @@ def test_add0():
     # One missing key
     with pytest.raises(MissingKeyError, match=msg("b")):
         c.add("ab", "mul", "a", "b")
-    with pytest.raises(MissingKeyError, match=msg("b")), pytest.warns(
-        DeprecationWarning
+    with (
+        pytest.raises(MissingKeyError, match=msg("b")),
+        pytest.warns(DeprecationWarning),
     ):
         c.add_product("ab", "a", "b")
 
     # Two missing keys
     with pytest.raises(MissingKeyError, match=msg("c", "b")):
         c.add("abc", "mul", "c", "a", "b")
-    with pytest.raises(MissingKeyError, match=msg("c", "b")), pytest.warns(
-        DeprecationWarning
+    with (
+        pytest.raises(MissingKeyError, match=msg("c", "b")),
+        pytest.warns(DeprecationWarning),
     ):
         c.add_product("abc", "c", "a", "b")
 

--- a/genno/tests/core/test_sparsedataarray.py
+++ b/genno/tests/core/test_sparsedataarray.py
@@ -4,17 +4,16 @@ from typing import cast
 import numpy as np
 import pandas as pd
 import pytest
-import sparse
 import xarray as xr
 from xarray.testing import assert_equal as assert_xr_equal
 
 import genno
 from genno import Computer
-from genno.core.sparsedataarray import HAS_SPARSE, SparseDataArray
+from genno.core.sparsedataarray import SparseDataArray
 from genno.testing import add_test_data, random_qty
 
-pytestmark = pytest.mark.skipif(
-    condition=not HAS_SPARSE,
+sparse = pytest.importorskip(
+    "sparse",
     reason="`sparse` not available → can't test SparseDataArray",
 )
 

--- a/genno/util.py
+++ b/genno/util.py
@@ -4,13 +4,10 @@ from inspect import Parameter, signature
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     Iterable,
     Mapping,
     MutableMapping,
     Optional,
-    Tuple,
-    Type,
     Union,
 )
 
@@ -104,7 +101,7 @@ def _invalid(unit: str, exc: Exception) -> Exception:
     chars = "".join(filter("-?$".__contains__, unit))
     msg = f"unit {unit!r} cannot be parsed; contains invalid character(s) {chars!r}"
     # Use the original class of `exc`, mapped in some cases
-    cls_map: Mapping[Type[Exception], Type[Exception]] = {TypeError: ValueError}
+    cls_map: Mapping[type[Exception], type[Exception]] = {TypeError: ValueError}
     return_cls = cls_map.get(type(exc), type(exc))
     return return_cls(msg)
 
@@ -187,7 +184,7 @@ def parse_units(data: Iterable, registry=None) -> "pint.Unit":
         raise _invalid(unit, e)
 
 
-_pars_cache: Dict[Tuple[Callable, int, Tuple], Mapping] = {}
+_pars_cache: dict[tuple[Callable, int, tuple], Mapping] = {}
 
 
 def free_parameters(func: Callable) -> Mapping:
@@ -223,7 +220,7 @@ def free_parameters(func: Callable) -> Mapping:
         return _pars_cache.setdefault(key, result)
 
 
-def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, MutableMapping]:
+def partial_split(func: Callable, kwargs: Mapping) -> tuple[Callable, MutableMapping]:
     """Forgiving version of :func:`functools.partial`.
 
     Returns a :ref:`partial object <python:partial-objects>` and leftover keyword
@@ -249,7 +246,7 @@ def partial_split(func: Callable, kwargs: Mapping) -> Tuple[Callable, MutableMap
         return func, extra  # Nothing to partial; return `func` as-is
 
 
-def units_with_multiplier(value: Optional[UnitLike]) -> Tuple["pint.Unit", float]:
+def units_with_multiplier(value: Optional[UnitLike]) -> tuple["pint.Unit", float]:
     """Separate units and multiplier from :any:`.UnitLike`.
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,15 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "dask [array] >= 2.14",
   "importlib_resources; python_version < '3.10'",
@@ -49,7 +49,6 @@ compat = ["genno[plotnine]", "genno[pyam]", "genno[sdmx]"]
 tests = [
   "genno[compat,graphviz]",
   "bottleneck",
-  "ipython <= 8.12; python_version <= '3.8'",
   "jupyter",
   "nbclient",
   "pytest",


### PR DESCRIPTION
Python 3.13 [will be released ~2024-10-01~ 2024-10-07](https://peps.python.org/pep-0719/). This PR is to:

- Check/confirm that genno is compatible with the new version. This includes:
  - The existence of compatible releases of upstream dependencies. If those releases are not immediately available, the PR can aid to monitor and track upstream issues:
    - hgrecco/pint#1969 —**blocking**.
    - [pyarrow 18.0.0](https://github.com/apache/arrow/milestone/64) —see [workaround below](https://github.com/khaeru/genno/pull/143#issuecomment-2410933264).
    - numba/llvmlite#1084 —for `sparse` only, currently addressed by omitting the install/tests of sparse in the CI matrix.
    - numba/numba#9413 —for `sparse` only.
- Drop support for Python 3.8, which will reach end-of-life (no more updates, even security updates) "approximately [during, before, or after] October 2024" [per PEP 569](https://peps.python.org/pep-0569/#lifespan).
  - [x] Remove any code marked as for Python 3.8 compatibility only. Depending on these changes, part or all of the functionality may remain usable with Python 3.8 if users have extreme need.
  - [x] Make any general clean-ups or improvements possible with [features available from Python 3.9](https://docs.python.org/3/whatsnew/3.9.html).
    - [x] Type hint using generics, e.g. list[str] instead of from typing import List/List[str].

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- [x] Update doc/whatsnew.rst
