### PR TITLE
Update workaround for #145

### DIFF
--- a/genno/testing/__init__.py
+++ b/genno/testing/__init__.py
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 # Common marks used in multiple places. Do not reuse keys.
 MARK = {
     "issue/145": pytest.mark.xfail(
-        condition="2024.10.0" == version("xarray"),
+        condition="2024.10.0" <= version("xarray"),
         reason="with SparseDataArray only (https://github.com/pydata/xarray/issues/9694)",
     ),
 }


### PR DESCRIPTION
The regression is still present in xarray 2024.11.0, so relax the mark condition to apply to versions equal to **or** greater than 2024.10.0.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, test changes only
- ~Update doc/whatsnew.rst~
