### PR TITLE
Adjust type hints for xarray 2025.3

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,8 +65,7 @@ jobs:
 
     - name: Run tests
       run: |
-        uv run --no-sync \
-          pytest \
+        pytest \
           --trace-config --color=yes --durations=20 -ra --verbose \
           --cov-report=xml --cov-report=term \
           --numprocesses=auto

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= --jobs=auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/doc/api-testing.rst
+++ b/doc/api-testing.rst
@@ -3,16 +3,69 @@ Test and documentation utilities
 
 .. autodata:: genno.core.computer.DEFAULT_WARN_ON_RESULT_TUPLE
 
+:mod:`genno.testing`
+====================
+
 .. automodule:: genno.testing
    :members:
 
 .. automodule:: genno.testing.jupyter
    :members:
 
+.. currentmodule:: genno.compat.sphinx
+
+Sphinx extensions
+=================
+
 .. automodule:: genno.compat.sphinx
+
+Document instances of :class:`.Operator`
+----------------------------------------
 
 .. automodule:: genno.compat.sphinx.autodoc_operator
    :members:
+
+Rewrite Sphinx references
+-------------------------
+
+To use this extension, add a setting :py:`reference_aliases` in :file:`conf.py` with content like the following:
+
+.. code-block:: python
+
+   # Mapping from expression → replacement.
+   # Order matters here; earlier entries are matched first.
+   reference_aliases = {
+       r"Quantity\.units": "genno.core.base.UnitsMixIn.units",
+       "KeyLike": ":data:`genno.core.key.KeyLike`",
+       "Quantity": "genno.core.attrseries.AttrSeries",
+       "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
+       #
+       # Many projects (including Sphinx itself!) do not have a py:module target in for the
+       # top-level module in objects.inv. Resolve these using :doc:`index` or similar for
+       # each project.
+       "dask$": ":std:doc:`dask:index`",
+       "pint$": ":std:doc:`pint <pint:index>`",
+       "plotnine$": ":class:`plotnine.ggplot`",
+       "pyarrow$": ":std:doc:`pyarrow <pyarrow:python/index>`",
+       "pyam$": ":std:doc:`pyam:index`",
+       "sphinx$": ":std:doc:`sphinx <sphinx:index>`",
+   }
+
+In this dictionary, the **keys** are regular expressions matching part or all of the target of a Sphinx reference.
+The **values** are replacement content *or* entire references; using the latter, it is possible to transmute references from one category to another.
+For example, in:
+
+.. code-block:: python
+
+   from genno.types import AnyQuantity
+
+   def myfunc(q: "AnyQuantity") -> None: ...
+
+…the string type annotation :py:`q: "AnyQuantity"` is automatically converted by Sphinx to ``:py:class:`AnyQuantity```.
+This will *always* fail, because :obj:`.AnyQuantity` is a TypeAlias, not a class.
+The :py:`reference_aliases` entry above replaces this auto-generated reference with one that resolves correctly.
+
+See also the comments in the example above about projects whose :file:`objects.inv` lacks a target for the module itself.
 
 .. automodule:: genno.compat.sphinx.rewrite_refs
    :members:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -418,29 +418,29 @@ This means that correct units are derived from the units of operands and attache
 Quantity has the following methods and attributes that exactly mirror the signatures and types of the corresponding :class:`.xarray.DataArray` items.
 
 .. autosummary::
-   ~genno.core.attrseries.AttrSeries.assign_coords
-   ~genno.core.attrseries.AttrSeries.bfill
-   ~genno.core.attrseries.AttrSeries.clip
-   ~genno.core.attrseries.AttrSeries.coords
-   ~genno.core.attrseries.AttrSeries.cumprod
-   ~genno.core.attrseries.AttrSeries.data
-   ~genno.core.attrseries.AttrSeries.dims
-   ~genno.core.attrseries.AttrSeries.drop
-   ~genno.core.attrseries.AttrSeries.drop_vars
-   ~genno.core.attrseries.AttrSeries.expand_dims
-   ~genno.core.attrseries.AttrSeries.ffill
-   ~genno.core.attrseries.AttrSeries.interp
-   ~genno.core.attrseries.AttrSeries.item
-   ~genno.core.attrseries.AttrSeries.rename
-   ~genno.core.attrseries.AttrSeries.sel
-   ~genno.core.attrseries.AttrSeries.shape
-   ~genno.core.attrseries.AttrSeries.shift
-   ~genno.core.attrseries.AttrSeries.squeeze
-   ~genno.core.attrseries.AttrSeries.sum
-   ~genno.core.attrseries.AttrSeries.to_dataframe
-   ~genno.core.attrseries.AttrSeries.to_series
-   ~genno.core.attrseries.AttrSeries.transpose
-   ~genno.core.attrseries.AttrSeries.where
+   ~core.attrseries.AttrSeries.assign_coords
+   ~core.attrseries.AttrSeries.bfill
+   ~core.attrseries.AttrSeries.clip
+   ~core.attrseries.AttrSeries.coords
+   ~core.attrseries.AttrSeries.cumprod
+   ~core.attrseries.AttrSeries.data
+   ~core.attrseries.AttrSeries.dims
+   ~core.attrseries.AttrSeries.drop
+   ~core.attrseries.AttrSeries.drop_vars
+   ~core.attrseries.AttrSeries.expand_dims
+   ~core.attrseries.AttrSeries.ffill
+   ~core.attrseries.AttrSeries.interp
+   ~core.attrseries.AttrSeries.item
+   ~core.attrseries.AttrSeries.rename
+   ~core.attrseries.AttrSeries.sel
+   ~core.attrseries.AttrSeries.shape
+   ~core.attrseries.AttrSeries.shift
+   ~core.attrseries.AttrSeries.squeeze
+   ~core.attrseries.AttrSeries.sum
+   ~core.attrseries.AttrSeries.to_dataframe
+   ~core.attrseries.AttrSeries.to_series
+   ~core.attrseries.AttrSeries.transpose
+   ~core.attrseries.AttrSeries.where
 
 .. autofunction:: configure
    :noindex:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,6 +83,7 @@ html_title = "genno"
 # Order matters here; earlier entries are matched first.
 reference_aliases = {
     r"Quantity\.units": "genno.core.base.UnitsMixIn.units",
+    "KeyLike": ":data:`genno.core.key.KeyLike`",
     "Quantity": "genno.core.attrseries.AttrSeries",
     "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
     #
@@ -145,8 +146,6 @@ napoleon_type_aliases = {
     "mapping": "collections.abc.Mapping",
     "sequence": "collections.abc.Sequence",
     "Path": "pathlib.Path",
-    # This package
-    "KeyLike": "genno.core.key.KeyLike",
     # Others
     "Code": "sdmx.model.common.Code",
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,7 +77,7 @@ html_theme_options = dict(
 
 html_title = "genno"
 
-# -- Options for genno.compat.sphinx.reference_alias -----------------------------------
+# -- Options for genno.compat.sphinx.rewrite_refs --------------------------------------
 
 # Mapping from expression → replacement.
 # Order matters here; earlier entries are matched first.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,10 +1,18 @@
 What's new
 **********
 
-.. _v1.28.1:
+.. _v1.28.2:
 
-.. Next release
-.. ============
+Next release
+============
+
+This release contains no functional changes.
+
+- Adjust type hints in :func:`.quantity_from_iamc` to avoid mypy_ errors with xarray >= 2025.3 (:pull:`166`).
+- Mark Sphinx extensions in :mod:`genno.compat.sphinx` as safe for parallel I/O (:program:`sphinx-build --jobs=...`) (:pull:`166`).
+  Expand documentation of these extensions.
+
+.. _v1.28.1:
 
 v1.28.1 (2025-02-20)
 ====================

--- a/genno/compat/pyam/operator.py
+++ b/genno/compat/pyam/operator.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from collections.abc import Callable, Collection, Iterable, Mapping
+from collections.abc import Callable, Collection, Hashable, Iterable, Mapping
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
@@ -264,14 +264,17 @@ def quantity_from_iamc(
     if isinstance(qty, pd.DataFrame):
         # Convert pandas.DataFrame to pyam.IamDataFrame
         qty = pyam.IamDataFrame(qty)
+
     if isinstance(qty, pyam.IamDataFrame):
         # Convert IamDataFrame to Quantity
         df = qty.as_pandas()
         qty = genno.Quantity(df.set_index(list(IAMC_DIMS & set(df.columns)))["value"])
 
+    assert isinstance(qty, genno.Quantity)
+
     # Identify a dimension whose name is in `targets`
-    def identify_dim(targets: Collection[str]) -> str:
-        result = list(filter(lambda d: d.lower() in targets, qty.dims))
+    def identify_dim(targets: Collection[str]) -> Hashable:
+        result = [d for d in qty.dims if str(d).lower() in targets]
         if len(result) != 1:
             raise ValueError(
                 f"cannot identify 1 unique dimension for {targets!r} among "

--- a/genno/compat/sphinx/autodoc_operator.py
+++ b/genno/compat/sphinx/autodoc_operator.py
@@ -16,6 +16,8 @@ class OperatorDocumenter(FunctionDocumenter):
         )
 
 
-def setup(app: "sphinx.application.Sphinx"):
+def setup(app: "sphinx.application.Sphinx") -> dict:
     """Configure :mod:`sphinx.ext.autodoc` to handle :class:`Operator` as functions."""
     app.add_autodocumenter(OperatorDocumenter, override=True)
+
+    return dict(parallel_read_safe=True, parallel_write_safe=True)

--- a/genno/compat/sphinx/rewrite_refs.py
+++ b/genno/compat/sphinx/rewrite_refs.py
@@ -92,10 +92,12 @@ def resolve_intersphinx_aliases(app, env, node, contnode):
         return missing_reference(app, env, node, contnode)
 
 
-def setup(app: "sphinx.application.Sphinx"):
+def setup(app: "sphinx.application.Sphinx") -> dict:
     """Connect :mod:`.rewrite_refs` event handlers."""
 
     app.add_config_value("reference_aliases", dict(), "")
 
     app.connect("doctree-read", resolve_internal_aliases)
     app.connect("missing-reference", resolve_intersphinx_aliases)
+
+    return dict(parallel_read_safe=True, parallel_write_safe=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ dependencies = [
 [project.optional-dependencies]
 # Graphviz, for Computer.describe()
 graphviz = ["graphviz"]
-docs = ["furo", "IPython"]
+docs = [
+  "furo",
+  "IPython",
+  "pickleshare",
+]
 # Specific packages for which compatibility is provided
 plotnine = ["plotnine"]
 pyam = ["pyam-iamc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ documentation = "https://genno.rtfd.io/en/stable/"
 
 [tool.coverage.report]
 omit = [
+  ".venv/*",
   "**/genno/compat/sphinx/*",
 ]
 exclude_also = [


### PR DESCRIPTION
A small change in xarray type hints caused mypy to error with this version, for instance [here](https://github.com/khaeru/genno/actions/runs/13962355372/job/39085906744#step:5:25):
```
genno/compat/pyam/operator.py:303: error: No overload variant of "pipe" of "DataWithCoords" matches argument types "Callable[[TQuantity, Mapping[Hashable, Iterable[Hashable]], DefaultNamedArg(bool, 'inverse'), DefaultNamedArg(bool, 'drop')], TQuantity]", "dict[str, list[str]]"  [call-overload]
genno/compat/pyam/operator.py:303: note: Possible overload variants:
genno/compat/pyam/operator.py:303: note:     def [P`15909, T] pipe(self, func: Callable[[SparseDataArray, **P], T], *args: P.args, **kwargs: P.kwargs) -> T
genno/compat/pyam/operator.py:303: note:     def [T] pipe(self, func: tuple[Callable[..., T], str], *args: Any, **kwargs: Any) -> T
```

This PR adjusts the hint.


### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
