### PR TITLE
Adjust 1 test for xarray v2025.6.0

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,10 +1,12 @@
 What's new
 **********
 
-.. _v1.28.2:
+Next release
+============
 
-.. Next release
-.. ============
+- Adjust test expectations for xarray >= 2025.6 (:pull:`173`).
+
+.. _v1.28.2:
 
 v1.28.2 (2025-03-25)
 ====================

--- a/genno/core/computer.py
+++ b/genno/core/computer.py
@@ -310,7 +310,7 @@ class Computer:
 
         if func:
             try:
-                # Use an implementation of Operator.add_task()
+                # Use an implementation of Operator.add_tasks()
                 return _warn_on_result(
                     self,
                     func.add_tasks(self, *args, **kwargs),  # type: ignore [attr-defined]

--- a/genno/tests/core/test_quantity.py
+++ b/genno/tests/core/test_quantity.py
@@ -185,12 +185,13 @@ class TestQuantity:
         # Exception raised when the values are of the wrong length
         with pytest.raises(
             ValueError,
-            match="conflicting sizes for dimension 'p': length 2 .* and length 3",
+            # NB "and" with xarray <= 2025.4; "but" with xarray >= 2025.6
+            match="conflicting sizes for dimension 'p': length 2 .* (but|and) length 3",
         ):
             a.assign_coords({"p": ["apple", "orange", "banana"]})
         with pytest.raises(
             ValueError,
-            match="conflicting sizes for dimension 'p': length 2 .* and length 1",
+            match="conflicting sizes for dimension 'p': length 2 .* (but|and) length 1",
         ):
             a.assign_coords({"p": ["apple"]})
 


### PR DESCRIPTION
xarray v2025.6.0 [was released 2025-06-10](https://docs.xarray.dev/en/stable/whats-new.html#v2025-06-0-jun-10-2025). With this new version, one test fails with SparseDataArray, [here](https://github.com/khaeru/genno/actions/runs/15576523967/job/43862410593#step:6:1607). 

The failure is not functional: no behaviour changes with this new version of xarray. Only the *wording* of an expected exception is changed:

> ValueError: conflicting sizes for dimension 'p': length 2 on the data **and** length 3 on coordinate 'p'

becomes:

> ValueError: conflicting sizes for dimension 'p': length 2 on the data **but** length 3 on coordinate 'p'

The PR adjusts the test only.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A; test changes only.
- [x] Update doc/whatsnew.rst
