### PR TITLE
Adjust for pandas 3.0.0

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: Run tests
       run: |
         pytest \
-          --trace-config --color=yes --durations=20 -ra --verbose \
+          --color=yes --durations=20 -ra --trace-config --verbose \
           --cov-report=xml --cov-report=term \
           --numprocesses=auto
       shell: bash

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- :mod:`genno` supports and is tested with `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,
+  released 2026-01-21 (:pull:`182`).
 
 v1.29.0 (2025-10-14)
 ====================

--- a/genno/compat/pandas.py
+++ b/genno/compat/pandas.py
@@ -1,40 +1,53 @@
 import logging
+from collections.abc import Iterator
 from contextlib import contextmanager
-from functools import lru_cache
+from functools import cache
 
 from packaging.version import Version, parse
+
+__all__ = [
+    "disable_copy_on_write",
+    "handles_parquet_attrs",
+    "manager_classes",
+    "version",
+]
 
 log = logging.getLogger(__name__)
 
 
-@lru_cache
+@cache
 def version() -> Version:
+    """Return the version of :mod:`pandas` as a :class:`packaging.version.Version`."""
     import pandas
 
     return parse(pandas.__version__)
 
 
 @contextmanager
-def disable_copy_on_write(name):
+def disable_copy_on_write(name: str) -> Iterator[None]:
     """Context manager to disable Pandas :ref:`pandas:copy_on_write`.
 
-    A message is logged with level :any:`logging.DEBUG` if the setting is changed.
+    A message is logged with level :any:`logging.DEBUG` if the setting is changed. The
+    fixture has no effect in pandas 3.0.0 and later, in which the option is always
+    enabled.
     """
     import pandas
 
-    stored = pandas.options.mode.copy_on_write
-    override_value = "warn" if version() >= Version("2.2.0") else False
+    cow = "mode.copy_on_write"
+
+    was_enabled = version() < Version("3") and pandas.get_option(cow)
+    if was_enabled:
+        log.debug(f"Override pandas.options.{cow} = True for {name}")
+        pandas.set_option(cow, False if Version("2.2") <= version() else "warn")
 
     try:
-        if stored is True:
-            log.debug(f"Override pandas.mode.options.copy_on_write = True for {name}")
-            pandas.options.mode.copy_on_write = override_value
         yield
     finally:
-        pandas.options.mode.copy_on_write = stored
+        if was_enabled:
+            pandas.set_option(cow, True)
 
 
-@lru_cache
+@cache
 def handles_parquet_attrs() -> bool:
     """Return :any:`True` if :mod:`pandas` can read/write attrs to/from Parquet files.
 
@@ -48,3 +61,16 @@ def handles_parquet_attrs() -> bool:
         return False
     else:
         return True
+
+
+@cache
+def manager_classes() -> tuple[type, ...]:
+    """Pandas class(es) for which a fast-path :py:`pd.Series.__init__()` can be used."""
+    if version() < Version("3"):
+        from pandas.core.internals.base import DataManager
+
+        return (DataManager,)
+    else:
+        from pandas.core.internals.managers import SingleBlockManager
+
+        return (SingleBlockManager,)

--- a/genno/core/attrseries.py
+++ b/genno/core/attrseries.py
@@ -10,8 +10,8 @@ import pandas.core.indexes.base as ibase
 import xarray as xr
 from packaging.version import Version
 from pandas.core.generic import NDFrame
-from pandas.core.internals.base import DataManager
 
+from genno.compat.pandas import manager_classes
 from genno.compat.pandas import version as pandas_version
 from genno.compat.xarray import (
     Coordinates,
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from _typeshed import SupportsRichComparisonT
 
     from genno.types import Dims
-
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +109,7 @@ class AttrSeries(BaseQuantity, pd.Series, DataArrayLike):
         **kwargs,
     ):
         # Emulate behaviour of Series.__init__
-        if isinstance(data, DataManager) and "fastpath" not in kwargs:
+        if isinstance(data, manager_classes()) and "fastpath" not in kwargs:
             if not (
                 0 == len(args) == len(kwargs) and attrs is None
             ):  # pragma: no cover

--- a/genno/operator.py
+++ b/genno/operator.py
@@ -474,6 +474,9 @@ def concat(*objs: "TQuantity", **kwargs) -> "TQuantity":
         # of `objs` to concatenate along.
         # FIXME this may result in non-unique indices; avoid this.
         kwargs.setdefault("dim", (objs[0].dims or [None])[0])
+        # Avoid FutureWarning: In a future version of xarray the default value for join
+        # will change from join="outer" to join="exact"…
+        kwargs.setdefault("join", "outer")
 
         result = xr.concat(cast(xr.DataArray, objs), **kwargs)._sda.convert()
 

--- a/genno/testing/__init__.py
+++ b/genno/testing/__init__.py
@@ -530,8 +530,18 @@ def parametrize_quantity_class(request):
 
 @pytest.fixture(params=[True, False], ids=["cow-true", "cow-false"])
 def parametrize_copy_on_write(monkeypatch, request):
-    """Fixture to run tests with pandas copy-on-write either enabled or disabled."""
-    monkeypatch.setattr(pd.options.mode, "copy_on_write", request.param)
+    """Fixture to run tests with pandas copy-on-write either enabled or disabled.
+
+    The fixture has no effect in pandas 3.0.0 and later, in which the copy_on_write
+    option is always enabled.
+    """
+    from packaging.version import Version
+
+    from genno.compat.pandas import version
+
+    if version() < Version("3"):
+        monkeypatch.setattr(pd.options.mode, "copy_on_write", request.param)
+
     yield
 
 

--- a/genno/tests/compat/test_pyam.py
+++ b/genno/tests/compat/test_pyam.py
@@ -269,7 +269,8 @@ def test_computer_as_pyam(caplog, tmp_path, test_data_path, dantzig_computer):
     assert ("var_cost::iamc", "var_cost::iamc") == keys
 
 
-def test_deprecated_convert_pyam():
+@pytest.mark.filterwarnings("ignore:Computer.convert_pyam")
+def test_deprecated_convert_pyam() -> None:
     """Test deprecated usage of `replace` parameter to as_pyam."""
     c = Computer()
 

--- a/genno/tests/test_operator.py
+++ b/genno/tests/test_operator.py
@@ -12,10 +12,12 @@ import pint
 import pytest
 import xarray as xr
 from numpy.testing import assert_allclose
+from packaging.version import Version
 from pandas.testing import assert_series_equal
 
 import genno
 from genno import Computer, operator, quote
+from genno.compat.pandas import version as pandas_version
 from genno.core.sparsedataarray import SparseDataArray
 from genno.operator import random_qty
 from genno.testing import (
@@ -373,7 +375,7 @@ def test_combine(ureg, data):
         operator.combine(x, x2, select=(dict(t=t_bar), dict(t=t_bar)), weights=(-1, 1))
 
 
-def test_concat(ureg, data):
+def test_concat(ureg, data) -> None:
     *_, t_foo, t_bar, x = data
 
     # Split x into two concatenateable quantities
@@ -383,12 +385,18 @@ def test_concat(ureg, data):
     # Concatenate
     operator.concat(a, b, dim="t")
 
-    # Concatenate twice on a new dimension
-    result = operator.concat(x, x, dim=pd.Index(["z1", "z2"], name="z"))
+    # XFAIL for https://github.com/pydata/xarray/issues/11098
+    with (
+        pytest.raises(TypeError)
+        if isinstance(x, SparseDataArray) and Version("3") <= pandas_version()
+        else nullcontext()
+    ):
+        # Concatenate twice on a new dimension
+        result = operator.concat(x, x, dim=pd.Index(["z1", "z2"], name="z"))
 
-    # NB for AttrSeries, the new dimension is first; for SparseDataArray, last
-    assert {"t", "y", "z"} == set(result.dims)
-    assert ureg.Unit("kg") == x.units == result.units
+        # NB for AttrSeries, the new dimension is first; for SparseDataArray, last
+        assert {"t", "y", "z"} == set(result.dims)
+        assert ureg.Unit("kg") == x.units == result.units
 
 
 def test_concat_dim_order(data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,11 @@ homepage = "https://github.com/khaeru/genno"
 repository = "https://github.com/khaeru/genno"
 documentation = "https://genno.rtfd.io/en/stable/"
 
+[tool.coverage.run]
+source = ["genno"]
+
 [tool.coverage.report]
 omit = [
-  ".venv/*",
   "**/genno/compat/sphinx/*",
 ]
 exclude_also = [
@@ -134,6 +136,7 @@ filterwarnings = [
   # TODO Remove when plotnine is adjusted for pandas 3.0
   "ignore:The 'mode.copy_on_write' option is deprecated.:DeprecationWarning:contextlib",
 ]
+test_paths = ["genno/tests"]
 # commented: This doubles the number of tests in the entire suite.
 # Use only to identify more narrow applications of the same fixture.
 # usefixtures = "parametrize_copy_on_write"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,11 @@ filterwarnings = [
   "ignore:datetime.datetime.utcfromtimestamp.. is deprecated.*:DeprecationWarning:dateutil",
   # .compat.pyam → ixmp4 → pandera
   "ignore:Importing pandas-specific classes:FutureWarning:pandera",
+  # Occurs with pandas >=3.x and plotnine <=0.15.2
+  # The warning type is pandas.errors.Pandas4Warning, but this is not available
+  # on Python 3.10 / pandas 2.3.x
+  # TODO Remove when plotnine is adjusted for pandas 3.0
+  "ignore:The 'mode.copy_on_write' option is deprecated.:DeprecationWarning:contextlib",
 ]
 # commented: This doubles the number of tests in the entire suite.
 # Use only to identify more narrow applications of the same fixture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ tests = [
   "bottleneck",
   "jupyter",
   "nbclient",
-  "pytest",
+  "pytest >= 9",
   "pytest-cov",
   "pytest-rerunfailures",
   "pytest-xdist",
@@ -117,26 +117,19 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.pytest.ini_options]
-addopts = "--cov=genno --cov-report="
+[tool.pytest]
+minversion = "9.0"
+addopts = ["--cov=genno", "--cov-report="]
 filterwarnings = [
-  "ignore:elementwise comparison failed.*:FutureWarning:genno.operator",
-  # Mirror (a) filter(s) set in .core.sparsedataarray
-  "ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning:sparse._coo.core",
-  # Upstream changes that won't affect genno
-  "ignore:configure_currency.*will no longer be the default:DeprecationWarning:iam_units",
-  "ignore:Jupyter is migrating its paths.*:DeprecationWarning:jupyter_client.connect",
-  # https://github.com/dateutil/dateutil/issues/1314
-  "ignore:datetime.datetime.utcfromtimestamp.. is deprecated.*:DeprecationWarning:dateutil",
-  # .compat.pyam → ixmp4 → pandera
-  "ignore:Importing pandas-specific classes:FutureWarning:pandera",
-  # Occurs with pandas >=3.x and plotnine <=0.15.2
-  # The warning type is pandas.errors.Pandas4Warning, but this is not available
-  # on Python 3.10 / pandas 2.3.x
-  # TODO Remove when plotnine is adjusted for pandas 3.0
+  # - Occurs with pandas >=3.x and plotnine <=0.15.2.
+  # - The warning type is pandas.errors.Pandas4Warning, but this is not available
+  #   on Python 3.10 / pandas 2.3.x.
+  # - TODO Remove when plotnine is adjusted for pandas 3.0.
   "ignore:The 'mode.copy_on_write' option is deprecated.:DeprecationWarning:contextlib",
 ]
-test_paths = ["genno/tests"]
+strict_config = true
+strict_markers = true
+testpaths = ["genno/tests"]
 # commented: This doubles the number of tests in the entire suite.
 # Use only to identify more narrow applications of the same fixture.
 # usefixtures = "parametrize_copy_on_write"


### PR DESCRIPTION
[Pandas 3.0.0 was released 2026-01-21](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html), with some changes that broke the test suite.

This PR adjusts.

- Work around pydata/xarray#11098 in the test suite.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- [x] Update doc/whatsnew.rst