### PR TITLE
Adjust for xarray 2026.1.0

### DIFF
--- a/genno/core/base.py
+++ b/genno/core/base.py
@@ -60,8 +60,8 @@ class UnitsMixIn:
 
         # Ensure there is not a mix of pint.Unit and pint.registry.Unit; this throws off
         # pint's internal logic
-        if ou.__class__ is not self.units.__class__:
-            ou = self.units.__class__(ou)
+        if type(ou) is not type(self.units):
+            ou = type(self.units)(ou)
 
         if rank(op) == 1:
             # Determine multiplicative factor to align `other` to `self`

--- a/genno/tests/test_operator.py
+++ b/genno/tests/test_operator.py
@@ -12,12 +12,10 @@ import pint
 import pytest
 import xarray as xr
 from numpy.testing import assert_allclose
-from packaging.version import Version
 from pandas.testing import assert_series_equal
 
 import genno
 from genno import Computer, operator, quote
-from genno.compat.pandas import version as pandas_version
 from genno.core.sparsedataarray import SparseDataArray
 from genno.operator import random_qty
 from genno.testing import (
@@ -385,18 +383,12 @@ def test_concat(ureg, data) -> None:
     # Concatenate
     operator.concat(a, b, dim="t")
 
-    # XFAIL for https://github.com/pydata/xarray/issues/11098
-    with (
-        pytest.raises(TypeError)
-        if isinstance(x, SparseDataArray) and Version("3") <= pandas_version()
-        else nullcontext()
-    ):
-        # Concatenate twice on a new dimension
-        result = operator.concat(x, x, dim=pd.Index(["z1", "z2"], name="z"))
+    # Concatenate twice on a new dimension
+    result = operator.concat(x, x, dim=pd.Index(["z1", "z2"], name="z"))
 
-        # NB for AttrSeries, the new dimension is first; for SparseDataArray, last
-        assert {"t", "y", "z"} == set(result.dims)
-        assert ureg.Unit("kg") == x.units == result.units
+    # NB for AttrSeries, the new dimension is first; for SparseDataArray, last
+    assert {"t", "y", "z"} == set(result.dims)
+    assert ureg.Unit("kg") == x.units == result.units
 
 
 def test_concat_dim_order(data):


### PR DESCRIPTION
[xarray 2026.1.0 was released 2026-01-28](https://docs.xarray.dev/en/stable/whats-new.html#v2026-01-0-jan-28-2026), including a fix for pydata/xarray#11098.
This PR removes a workaround for this issue, introduced in #182.

Also:
- Use `type(…)` instead of `….__class__` in UnitsMixIn.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, test suite changes only.
- ~Update doc/whatsnew.rst~ ditto
