### PR TITLE
Adjust for incompatibility of ixmp4 v0.15.x / pyam-iamc v3.2.0

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -15,6 +15,8 @@ Next release
   and may contain bugs (for instance, :issue:`170`)
   or be incompatible with newer versions of Python or other dependencies.
   It is recommended to use the newest versions of all dependencies.
+- Handle incompatibilities between certain versions of :mod:`pyam` (``pyam-iamc``) less than v3.3.1
+  and :mod:`ixmp4` version 0.15.0 or greater (:issue:`192`, :pull:`193`).
 - Improved type hints for downstream applications (:issue:`174`, :pull:`188`).
   In particular,
   :meth:`.Computer.add` is typed to return a single :class:`.Key` or :class:`str`,

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -1,10 +1,10 @@
 import logging
 from functools import partial
+from importlib import import_module
 from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 from genno import Computer, Key
-from genno.config import handles
 from genno.core.key import single_key
 
 if TYPE_CHECKING:
@@ -12,12 +12,23 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-#: :class:`bool` indicating whether :mod:`pyam` is available.
-HAS_PYAM = find_spec("pyam") is not None
+#: :class:`bool` indicating whether :mod:`pyam` is available. If either the package is
+#: not installed, or it is installed but raises some exception on import, this will be
+#: :any:`False`, and the operators and configuration handling in the current module will
+#: be unavailable.
+HAS_PYAM = False
+
+if find_spec("pyam"):
+    try:
+        import_module("pyam")
+    except Exception as e:
+        # Handle pyam is installed but cannot be imported
+        log.warning(f"{__name__} unavailable due to {e}")
+    else:
+        HAS_PYAM = True
 
 
-@handles("iamc")
-def iamc(c: Computer, info: "MutableMapping") -> None:
+def handle_config(c: Computer, info: "MutableMapping") -> None:
     """Handle one entry from the ``iamc:`` config section."""
     try:
         c.require_compat("pyam")
@@ -75,3 +86,10 @@ def iamc(c: Computer, info: "MutableMapping") -> None:
 
     log.info(f"Add {repr(keys[-1])} from {repr(keys[0])}")
     log.debug(f"    {len(keys)} keys total")
+
+
+if HAS_PYAM:
+    # Register the configuration handler only if pyam is actually available
+    import genno.config
+
+    genno.config.handles("iamc")(handle_config)

--- a/genno/compat/pyam/operator.py
+++ b/genno/compat/pyam/operator.py
@@ -7,14 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from warnings import warn
 
-import pyam
-
 import genno
 import genno.operator
 from genno.core.key import Key, KeyLike
 from genno.core.operator import Operator
 
-from . import util
+from . import HAS_PYAM, util
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -24,13 +22,20 @@ if TYPE_CHECKING:
     from genno.core.computer import Computer
     from genno.types import AnyQuantity, HasScenarioIdentifiers, TQuantity
 
-log = logging.getLogger(__name__)
-
-
 __all__ = [
     "as_pyam",
     "quantity_from_iamc",
 ]
+
+log = logging.getLogger(__name__)
+
+if HAS_PYAM:
+    from pyam import IamDataFrame
+else:
+    # pyam not available → define a dummy class for register() decorators
+
+    class IamDataFrame:  # type: ignore [no-redef]
+        pass
 
 
 @Operator.define()
@@ -46,7 +51,7 @@ def as_pyam(
     prepend_name: bool = True,
     model_name: str | None = None,
     scenario_name: str | None = None,
-) -> "pyam.IamDataFrame":
+) -> "IamDataFrame":
     """Return a :class:`pyam.IamDataFrame` containing the data from `quantity`.
 
     Warnings are logged if the arguments result in additional, unhandled columns in the
@@ -219,17 +224,19 @@ def add_as_pyam(
 
 
 @genno.operator.concat.register
-def _(*args: pyam.IamDataFrame, **kwargs: Any) -> "pyam.IamDataFrame":
+def _(*args: "IamDataFrame", **kwargs: Any) -> "IamDataFrame":
     """Concatenate `args`, which must all be :class:`pyam.IamDataFrame`.
 
     Otherwise, equivalent to :func:`genno.operator.concat`.
     """
+    import pyam
+
     # Use pyam.concat() top-level function
     return pyam.concat(args, **kwargs)
 
 
 def quantity_from_iamc(
-    qty: "TQuantity | pyam.IamDataFrame | pandas.DataFrame",
+    qty: "TQuantity | IamDataFrame | pandas.DataFrame",
     variable: str,
     *,
     fail: int | str = "warning",
@@ -259,6 +266,7 @@ def quantity_from_iamc(
     unique_units_from_dim
     """
     import pandas as pd
+    from pyam import IamDataFrame
 
     from genno.operator import relabel, select, unique_units_from_dim
 
@@ -266,9 +274,9 @@ def quantity_from_iamc(
 
     if isinstance(qty, pd.DataFrame):
         # Convert pandas.DataFrame to pyam.IamDataFrame
-        qty = pyam.IamDataFrame(qty)
+        qty = IamDataFrame(qty)
 
-    if isinstance(qty, pyam.IamDataFrame):
+    if isinstance(qty, IamDataFrame):
         # Convert IamDataFrame to Quantity
         df = qty.as_pandas()
         qty = genno.Quantity(df.set_index(list(IAMC_DIMS & set(df.columns)))["value"])
@@ -313,7 +321,7 @@ def quantity_from_iamc(
 
 
 @genno.operator.write_report.register
-def _(quantity: pyam.IamDataFrame, path: PathLike, kwargs: Any = None) -> None:
+def _(quantity: "IamDataFrame", path: PathLike, kwargs: Any = None) -> None:
     """Write  `obj` to the file at `path`.
 
     If `obj` is a :class:`pyam.IamDataFrame` and `path` ends with ".csv" or ".xlsx",

--- a/genno/tests/compat/test_compat.py
+++ b/genno/tests/compat/test_compat.py
@@ -1,10 +1,23 @@
+from genno import Computer
+
+
 def test_import_pyam() -> None:
-    """.compat.pyam.operator is populated only if pyam itself is installed.
+    """:func:`.as_pyam` operator is available only if pyam itself is installed.
 
     Unlike the tests in :mod:`.test_pyam`, this test should pass regardless of whether
     or not pyam is installed.
     """
-    from genno.compat.pyam import HAS_PYAM, operator
 
-    # Same value, either True or False
-    assert HAS_PYAM is hasattr(operator, "as_pyam")
+    from genno.compat.pyam import HAS_PYAM
+
+    c = Computer()
+
+    try:
+        c.require_compat("pyam")
+    except ModuleNotFoundError:
+        pass  # Fails if HAS_PYAM is False
+
+    # Try to retrieve the as_pyam() operator
+    operator = c.get_operator("as_pyam")
+
+    assert callable(operator) if HAS_PYAM else operator is None

--- a/genno/tests/compat/test_pyam.py
+++ b/genno/tests/compat/test_pyam.py
@@ -22,7 +22,9 @@ if TYPE_CHECKING:
     import pathlib
 
 # Skip this entire file if pyam is not installed
-pyam = pytest.importorskip("pyam", reason="pyam-iamc not installed")
+pyam = pytest.importorskip(
+    "pyam", reason="pyam-iamc not installed", exc_type=ImportError
+)
 
 # Warning emitted by pandas ≥ 2.1.0 with pyam 1.9.0
 pytestmark = pytest.mark.filterwarnings(

--- a/genno/tests/test_config.py
+++ b/genno/tests/test_config.py
@@ -34,7 +34,10 @@ def test_handlers() -> None:
     third_party_handlers = 0
     try:
         import_module("ixmp")
-    except ImportError:
+    except (
+        AttributeError,  # Occurs with ixmp4 ≥0.15.0 and ixmp <3.12
+        ImportError,
+    ):
         pass
     else:  # pragma: no cover
         third_party_handlers += 2


### PR DESCRIPTION
Previously `HAS_PYAM` was True if pyam-iamc was installed. Now it is only True if the package is installed **and** importable without exceptions such as the one in #192.

Closes #192. Note that CI workflows are not adjusted; at least one job for each OS (e.g. `ubuntu-latest-py3.10`) *is* getting compatible versions of the two packages, as shown by test coverage remaining the same. As the upstream version(s) advance, these tests *should* run again on more recent jobs.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation.
- [x] Update doc/whatsnew.rst