### PR TITLE
Release v1.30.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ The package name is warning, by reference, to the adage “When you hold a hamme
 License
 =======
 
-Copyright © 2018–2025 genno contributors.
+Copyright © 2018–2026 genno contributors.
 
 Licensed under the GNU General Public License, version 3.0.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,7 +60,7 @@ Packages that extend :mod:`genno` include:
 License
 =======
 
-Copyright © 2018–2025 genno contributors.
+Copyright © 2018–2026 genno contributors.
 
 Licensed under the GNU General Public License, version 3.0.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-Next release
-============
+.. Next release
+.. ============
+
+v1.30.0 (2026-05-17)
+====================
 
 - :mod:`genno` supports and is tested with dask 2025.4.0 and later (:issue:`171`, :pull:`188`).
 - Increased minimum versions for dependencies:


### PR DESCRIPTION
- Bump copyright year to 2026
- Mark v1.30.0 in doc/whatsnew

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- [x] Update doc/whatsnew.rst
