### PR TITLE
Revert rename of iamc() to handle_config()

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bug fix: in v1.30.0,
+  :func:`.iamc` was not importable from :mod:`genno.compat.pyam` (:pull:`195`)
 
 v1.30.0 (2026-05-17)
 ====================

--- a/genno/compat/pyam/__init__.py
+++ b/genno/compat/pyam/__init__.py
@@ -28,7 +28,7 @@ if find_spec("pyam"):
         HAS_PYAM = True
 
 
-def handle_config(c: Computer, info: "MutableMapping") -> None:
+def iamc(c: Computer, info: "MutableMapping") -> None:
     """Handle one entry from the ``iamc:`` config section."""
     try:
         c.require_compat("pyam")
@@ -92,4 +92,4 @@ if HAS_PYAM:
     # Register the configuration handler only if pyam is actually available
     import genno.config
 
-    genno.config.handles("iamc")(handle_config)
+    genno.config.handles("iamc")(iamc)

--- a/genno/tests/compat/test_compat.py
+++ b/genno/tests/compat/test_compat.py
@@ -8,7 +8,10 @@ def test_import_pyam() -> None:
     or not pyam is installed.
     """
 
-    from genno.compat.pyam import HAS_PYAM
+    # Name 'iamc' can be imported; as in e.g. message-ix-models
+    from genno.compat.pyam import HAS_PYAM, iamc
+
+    del iamc
 
     c = Computer()
 


### PR DESCRIPTION
This change caused CI failures downstream, in iiasa/message-ix-models.

Add a test to confirm the import works.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A: bugfix only
- [x] Update doc/whatsnew.rst
